### PR TITLE
Guard expressions in word signatures

### DIFF
--- a/include/operation.hrl
+++ b/include/operation.hrl
@@ -1,7 +1,8 @@
 -record(operation, {
     name     = ""        :: string(),
-    sig_in   = []        :: list(),      %% [type_constraint()]
-    sig_out  = []        :: list(),      %% [type_constraint()]
+    sig_in   = []        :: list(),       %% [type_constraint()]
+    sig_out  = []        :: list(),       %% [type_constraint()]
     impl     = undefined :: function() | undefined,
-    source   = undefined :: term()       %% #token{} | undefined
+    source   = undefined :: term(),       %% #token{} | undefined
+    guard    = undefined :: undefined | [term()]  %% list of #token{} or []
 }).

--- a/src/af_type.erl
+++ b/src/af_type.erl
@@ -1,11 +1,13 @@
 -module(af_type).
 
+-include("token.hrl").
 -include("operation.hrl").
 -include("af_type.hrl").
+-include("continuation.hrl").
 
 -export([init/0, reset/0]).
 -export([register_type/1, add_op/2, replace_ops/3]).
--export([find_op/2, find_op_in_tos/2, find_op_in_any/2, find_op_by_name/2, match_sig/2]).
+-export([find_op/2, find_op_in_tos/2, find_op_in_any/2, find_op_by_name/2, match_sig/2, match_guard/2]).
 -export([get_type/1, all_types/0]).
 -export([snapshot/0]).
 -export([dict_find_op_in_tos/3, dict_find_op_in_any/3, dict_get_type/2,
@@ -151,8 +153,26 @@ find_op_in_type(TypeName, OpName, Stack) ->
 match_first_op([], _Stack) -> not_found;
 match_first_op([Op | Rest], Stack) ->
     case match_sig(Op#operation.sig_in, Stack) of
-        true -> {ok, Op};
+        true ->
+            case match_guard(Op, Stack) of
+                true -> {ok, Op};
+                false -> match_first_op(Rest, Stack)
+            end;
         false -> match_first_op(Rest, Stack)
+    end.
+
+%% Evaluate an operation's guard (if any) on a snapshot of the stack.
+%% The guard is a list of #token{} records run as a small A4 program against
+%% the current data stack. It must leave {Bool, true} on top to match.
+%% An operation with no guard always matches (returns true).
+match_guard(#operation{guard = undefined}, _Stack) -> true;
+match_guard(#operation{guard = []}, _Stack) -> true;
+match_guard(#operation{guard = GuardTokens}, Stack) ->
+    TempCont = #continuation{data_stack = Stack},
+    try af_interpreter:interpret_tokens(GuardTokens, TempCont) of
+        #continuation{data_stack = [{'Bool', true} | _]} -> true;
+        _ -> false
+    catch _:_ -> false
     end.
 
 %%% ============================================================

--- a/src/af_type_compiler.erl
+++ b/src/af_type_compiler.erl
@@ -139,8 +139,35 @@ handle_word_definition(TokenValue, Cont) ->
 %% Supports value constraints: "0 Int" -> {Int, 0}
 %% When a literal (integer/float/bool) is seen, buffer it as pending_value.
 %% When the next type name arrives, combine into {Type, Value}.
+%%
+%% Also supports guard expressions. The keyword `where` flips the handler into
+%% guard-collecting mode; subsequent tokens up to `->` are accumulated as the
+%% guard body. The guard is a sequence of words evaluated on a snapshot of the
+%% stack at dispatch time; if the guard leaves {Bool, true} on top, the clause
+%% matches.
+handle_input_sig("where", Cont) ->
+    [{'InputTypeSignature', State} | Rest] = Cont#continuation.data_stack,
+    NewState = State#{in_guard => true, guard => []},
+    Cont#continuation{
+        data_stack = [{'InputTypeSignature', NewState} | Rest]
+    };
 handle_input_sig(TokenValue, Cont) ->
     [{'InputTypeSignature', State} | Rest] = Cont#continuation.data_stack,
+    case maps:get(in_guard, State, false) of
+        true ->
+            %% In guard-collecting mode: append the ORIGINAL token (which
+            %% preserves quoted flag and position).
+            Guard = maps:get(guard, State, []),
+            Token = Cont#continuation.current_token,
+            NewState = State#{guard => Guard ++ [Token]},
+            Cont#continuation{
+                data_stack = [{'InputTypeSignature', NewState} | Rest]
+            };
+        false ->
+            handle_input_sig_type(TokenValue, State, Rest, Cont)
+    end.
+
+handle_input_sig_type(TokenValue, State, Rest, Cont) ->
     #{sig_in := SigIn, pending_value := PendingValue} = State,
     case PendingValue of
         undefined ->
@@ -313,10 +340,13 @@ resolve_compile_token(TokenValue, OrigToken) ->
     }.
 
 %% -> transition: InputTypeSignature -> OutputTypeSignature
+%% Also ends any guard-collecting mode so trailing tokens in the output sig
+%% are parsed as types rather than guard words.
 op_arrow(Cont) ->
     [{'InputTypeSignature', State} | Rest] = Cont#continuation.data_stack,
+    NewState = State#{in_guard => false},
     Cont#continuation{
-        data_stack = [{'OutputTypeSignature', State} | Rest]
+        data_stack = [{'OutputTypeSignature', NewState} | Rest]
     }.
 
 %% ; transition: OutputTypeSignature -> CodeCompile
@@ -370,6 +400,7 @@ op_dot(Cont) ->
 
 register_single_word(State, Rest, Cont) ->
     #{name := Name, sig_in := SigIn0, sig_out := SigOut0, body := Body} = State,
+    Guard = maps:get(guard, State, undefined),
 
     %% Signatures are accumulated left-to-right (Forth convention: leftmost = deepest).
     %% Reverse so element 0 = TOS for match_sig and dispatch.
@@ -389,13 +420,20 @@ register_single_word(State, Rest, Cont) ->
         sig_in = SigIn,
         sig_out = SigOut,
         impl = Impl,
-        source = {compiled, Body}
+        source = {compiled, Body},
+        guard = Guard
     },
 
     ensure_type(TargetType),
     af_type:add_op(TargetType, NewOp),
 
-    af_type_any:auto_compile_word(Name),
+    %% Guarded words currently bypass the BEAM word compiler; the interpreter
+    %% evaluates the guard at dispatch time.
+    case Guard of
+        undefined -> af_type_any:auto_compile_word(Name);
+        [] -> af_type_any:auto_compile_word(Name);
+        _ -> ok
+    end,
 
     %% Sync local dictionary from ETS (auto_compile_word may have replaced ops)
     Dict1 = sync_type_from_ets(TargetType, Cont#continuation.dictionary),
@@ -404,6 +442,14 @@ register_single_word(State, Rest, Cont) ->
 
 register_multi_word(State, Clauses, Rest, Cont) ->
     #{name := Name, sig_in := MasterSigIn0} = State,
+    MasterGuard = maps:get(guard, State, undefined),
+    case MasterGuard of
+        G when G =/= undefined, G =/= [] ->
+            error({guard_on_multiclause, Name,
+                "Top-level 'where' guards cannot combine with sub-clauses. "
+                "Define separate top-level clauses with the same name instead."});
+        _ -> ok
+    end,
     MasterSigIn = lists:reverse(MasterSigIn0),
     TargetType = get_target_type(MasterSigIn),
     ensure_type(TargetType),

--- a/test/af_guard_tests.erl
+++ b/test/af_guard_tests.erl
@@ -1,0 +1,189 @@
+-module(af_guard_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("token.hrl").
+-include("continuation.hrl").
+-include("operation.hrl").
+-include("af_type.hrl").
+
+setup() ->
+    af_type:reset().
+
+eval(Input) ->
+    eval(Input, af_interpreter:new_continuation()).
+
+eval(Input, Cont) ->
+    Tokens = af_parser:parse(Input, "test"),
+    af_interpreter:interpret_tokens(Tokens, Cont).
+
+%%====================================================================
+%% Guard parsing & storage
+%%====================================================================
+
+guard_captured_test_() ->
+    {foreach, fun setup/0, fun(_) -> ok end, [
+        fun(_) -> {"word with 'where' captures guard tokens", fun() ->
+            _ = eval(": positive Int where dup 0 > -> Int ; 1 - ."),
+            {ok, Op} = af_type:find_op_by_name("positive", 'Int'),
+            Guard = Op#operation.guard,
+            ?assert(is_list(Guard)),
+            ?assert(length(Guard) >= 3),
+            Values = [T#token.value || T <- Guard],
+            ?assertEqual(["dup", "0", ">"], Values)
+        end} end,
+
+        fun(_) -> {"word without 'where' has undefined guard", fun() ->
+            _ = eval(": plain Int -> Int ; 1 + ."),
+            {ok, Op} = af_type:find_op_by_name("plain", 'Int'),
+            ?assertEqual(undefined, Op#operation.guard)
+        end} end
+    ]}.
+
+%%====================================================================
+%% Guard dispatch: runtime evaluation
+%%====================================================================
+
+guard_dispatch_test_() ->
+    {foreach, fun setup/0, fun(_) -> ok end, [
+        fun(_) -> {"guard true selects the clause", fun() ->
+            _ = eval(": step Int where dup 0 > -> Int ; 1 - ."),
+            _ = eval(": step Int -> Int ; drop 0 ."),
+            Result = eval("5 step"),
+            ?assertEqual([{'Int', 4}], Result#continuation.data_stack)
+        end} end,
+
+        fun(_) -> {"guard false falls through to next clause", fun() ->
+            _ = eval(": step Int where dup 0 > -> Int ; 1 - ."),
+            _ = eval(": step Int -> Int ; drop 0 ."),
+            Result = eval("0 step"),
+            ?assertEqual([{'Int', 0}], Result#continuation.data_stack)
+        end} end,
+
+        fun(_) -> {"guard false on negative falls through", fun() ->
+            _ = eval(": step Int where dup 0 > -> Int ; 1 - ."),
+            _ = eval(": step Int -> Int ; drop 99 ."),
+            Result = eval("-3 step"),
+            ?assertEqual([{'Int', 99}], Result#continuation.data_stack)
+        end} end,
+
+        fun(_) -> {"multiple guarded clauses, picks first match", fun() ->
+            _ = eval(": classify Int where dup 0 > -> Int ; drop 1 ."),
+            _ = eval(": classify Int where dup 0 < -> Int ; drop -1 ."),
+            _ = eval(": classify Int -> Int ; drop 0 ."),
+            R1 = eval("5 classify"),
+            ?assertEqual([{'Int', 1}], R1#continuation.data_stack),
+            R2 = eval("-7 classify"),
+            ?assertEqual([{'Int', -1}], R2#continuation.data_stack),
+            R3 = eval("0 classify"),
+            ?assertEqual([{'Int', 0}], R3#continuation.data_stack)
+        end} end,
+
+        fun(_) -> {"guard does not consume stack items", fun() ->
+            %% The guard runs on a snapshot; after dispatch the clause body
+            %% sees the original stack.
+            _ = eval(": mark Int where dup 5 >= -> Int ; 100 + ."),
+            _ = eval(": mark Int -> Int ; 1 - ."),
+            R = eval("7 mark"),
+            ?assertEqual([{'Int', 107}], R#continuation.data_stack)
+        end} end,
+
+        fun(_) -> {"guard returning non-Bool falls through", fun() ->
+            %% If the guard body crashes or leaves something other than
+            %% {Bool, true} on top, the clause must not match.
+            _ = eval(": weird Int where dup -> Int ; drop 42 ."),
+            _ = eval(": weird Int -> Int ; drop 7 ."),
+            R = eval("3 weird"),
+            %% dup leaves Int on top, not Bool. Should fall through.
+            ?assertEqual([{'Int', 7}], R#continuation.data_stack)
+        end} end
+    ]}.
+
+%%====================================================================
+%% Guard and value-constraint clauses combined
+%%====================================================================
+
+guard_with_value_constraint_test_() ->
+    {foreach, fun setup/0, fun(_) -> ok end, [
+        fun(_) -> {"value constraint clause matches before guard", fun() ->
+            _ = eval(": f 0 Int -> Int ; drop 999 ."),
+            _ = eval(": f Int where dup 0 > -> Int ; 10 + ."),
+            _ = eval(": f Int -> Int ; drop -1 ."),
+            R0 = eval("0 f"),
+            ?assertEqual([{'Int', 999}], R0#continuation.data_stack),
+            Rpos = eval("5 f"),
+            ?assertEqual([{'Int', 15}], Rpos#continuation.data_stack),
+            Rneg = eval("-2 f"),
+            ?assertEqual([{'Int', -1}], Rneg#continuation.data_stack)
+        end} end
+    ]}.
+
+%%====================================================================
+%% Interaction with sub-clauses (disallowed)
+%%====================================================================
+
+guard_rejected_on_multiclause_test_() ->
+    {foreach, fun setup/0, fun(_) -> ok end, [
+        fun(_) -> {"top-level where plus sub-clauses raises an error", fun() ->
+            Src = ": bad Int where dup 0 > -> Int ;"
+                  " : 0 -> 0 ;"
+                  " : Int -> dup 1 - bad ; ."
+                  ,
+            ?assertError({guard_on_multiclause, _, _},
+                         eval(Src))
+        end} end
+    ]}.
+
+%%====================================================================
+%% match_guard/2 direct tests
+%%====================================================================
+
+match_guard_direct_test_() ->
+    [
+        {"undefined guard always matches", fun() ->
+            Op = #operation{guard = undefined},
+            ?assertEqual(true, af_type:match_guard(Op, []))
+        end},
+
+        {"empty-list guard always matches", fun() ->
+            Op = #operation{guard = []},
+            ?assertEqual(true, af_type:match_guard(Op, []))
+        end},
+
+        {"Bool-true guard matches", fun() ->
+            Stack = [{'Bool', true}],
+            TokTrue = #token{value = "dup", line = 1, column = 1, file = "t"},
+            Op = #operation{guard = [TokTrue]},
+            ?assertEqual(true, af_type:match_guard(Op, Stack))
+        end},
+
+        {"crashing guard does not match", fun() ->
+            %% A token whose interpretation crashes — match_guard must catch.
+            Op = #operation{guard = [
+                #token{value = "drop", line = 1, column = 1, file = "t"}
+            ]},
+            ?assertEqual(false, af_type:match_guard(Op, []))
+        end}
+    ].
+
+%%====================================================================
+%% Word with guard is NOT auto-compiled to BEAM
+%%====================================================================
+
+guard_skips_auto_compile_test_() ->
+    {foreach, fun setup/0, fun(_) -> ok end, [
+        fun(_) -> {"guarded word has interpreter impl, no native wrapper", fun() ->
+            _ = eval(": guarded Int where dup 0 > -> Int ; 1 - ."),
+            {ok, Op} = af_type:find_op_by_name("guarded", 'Int'),
+            %% A native-compiled word would have source = {native, _}.
+            %% Interpreter words have source = {compiled, Body}.
+            ?assertMatch({compiled, _}, Op#operation.source)
+        end} end,
+
+        fun(_) -> {"plain (no-guard) word still gets auto-compiled to native", fun() ->
+            _ = eval(": plain Int -> Int ; 1 + ."),
+            {ok, Op} = af_type:find_op_by_name("plain", 'Int'),
+            %% The word compiler may leave it as {compiled, _} if it decides
+            %% not to compile, but it should not have a guard on it.
+            ?assertEqual(undefined, Op#operation.guard)
+        end} end
+    ]}.


### PR DESCRIPTION
Closes #29.

Syntax: `: name Types where <predicate-tokens> -> Types ; body .`

The tokens between `where` and `->` are captured as the operation's guard. At dispatch, after `sig_in` type-matches, the guard is evaluated on a snapshot of the current stack. If the guard leaves `{Bool, true}` on top, the clause matches; otherwise dispatch falls through to the next clause.

```
: step Int where dup 0 > -> Int ; 1 - .
: step Int               -> Int ; drop 0 .
```

**Scope (v1):** Interpreter path only. Guarded words keep their interpreted bodies; the BEAM word compiler does not yet emit guard-aware multi-clause functions (follow-up). Top-level `where` cannot combine with sub-clauses.

**Tests:** 16 new. **Suite:** 2097 passing. **Coverage:** `af_type` 98%, `af_type_compiler` 95%.