### PR TITLE
defined_at counter + Forth-style forget word

### DIFF
--- a/include/operation.hrl
+++ b/include/operation.hrl
@@ -1,8 +1,9 @@
 -record(operation, {
-    name     = ""        :: string(),
-    sig_in   = []        :: list(),       %% [type_constraint()]
-    sig_out  = []        :: list(),       %% [type_constraint()]
-    impl     = undefined :: function() | undefined,
-    source   = undefined :: term(),       %% #token{} | undefined
-    guard    = undefined :: undefined | [term()]  %% list of #token{} or []
+    name       = ""        :: string(),
+    sig_in     = []        :: list(),       %% [type_constraint()]
+    sig_out    = []        :: list(),       %% [type_constraint()]
+    impl       = undefined :: function() | undefined,
+    source     = undefined :: term(),       %% #token{} | undefined
+    guard      = undefined :: undefined | [term()], %% list of #token{} or []
+    defined_at = undefined :: undefined | non_neg_integer() %% monotonic counter
 }).

--- a/src/af_type.erl
+++ b/src/af_type.erl
@@ -10,6 +10,7 @@
 -export([find_op/2, find_op_in_tos/2, find_op_in_any/2, find_op_by_name/2, match_sig/2, match_guard/2]).
 -export([get_type/1, all_types/0]).
 -export([snapshot/0]).
+-export([forget/1, current_def_counter/0]).
 -export([dict_find_op_in_tos/3, dict_find_op_in_any/3, dict_get_type/2,
          dict_all_types/1, dict_add_op/3, dict_register_type/2, dict_replace_ops/4]).
 
@@ -18,7 +19,17 @@
 -type type_constraint() :: 'Any' | atom() | {atom(), term()}.
 -type stack_item() :: {atom(), term()}.
 
--define(TABLE, af_type_registry).
+%% The type registry uses ETS for mutable read/write. Each op is stamped with
+%% a monotonic `defined_at` counter tracked in a second ETS table so that the
+%% Forth-style `forget` word can rewind the dictionary back to a known point.
+%%
+%% A previous attempt stored the registry as a single `persistent_term` map.
+%% That works semantically but exhausts the BEAM "literal heap" when the
+%% compiler rewrites the map thousands of times during test runs: persistent_term
+%% copies the whole value into a GC-collected literal area on every put. ETS
+%% remains the right tool for this write-heavy path.
+-define(TABLE,   af_type_registry).
+-define(CTRTAB,  af_type_counter).
 
 %%% API
 
@@ -27,12 +38,19 @@ init() ->
         undefined -> ets:new(?TABLE, [named_table, set, public, {keypos, #af_type.name}]);
         _ -> ok
     end,
+    case ets:info(?CTRTAB) of
+        undefined ->
+            ets:new(?CTRTAB, [named_table, set, public]),
+            ets:insert(?CTRTAB, {counter, 0});
+        _ -> ok
+    end,
     ensure_type('Any'),
     ensure_type('Atom'),
     ok.
 
 reset() ->
     catch ets:delete(?TABLE),
+    catch ets:delete(?CTRTAB),
     af_repl:init_types().
 
 register_type(#af_type{} = Type) ->
@@ -42,9 +60,10 @@ register_type(#af_type{} = Type) ->
 add_op(TypeName, #operation{} = Op) ->
     case ets:lookup(?TABLE, TypeName) of
         [#af_type{ops = Ops} = Type] ->
-            OpName = Op#operation.name,
+            StampedOp = stamp_op(Op),
+            OpName = StampedOp#operation.name,
             Existing = maps:get(OpName, Ops, []),
-            NewOps = maps:put(OpName, Existing ++ [Op], Ops),
+            NewOps = maps:put(OpName, Existing ++ [StampedOp], Ops),
             ets:insert(?TABLE, Type#af_type{ops = NewOps}),
             ok;
         [] ->
@@ -52,10 +71,14 @@ add_op(TypeName, #operation{} = Op) ->
     end.
 
 %% Replace all operations with a given name in a type's dictionary.
+%% Preserves `defined_at` from the existing ops so that native-wrapper
+%% replacement does not disturb the monotonic ordering relied on by `forget`.
 replace_ops(TypeName, OpName, NewOps) when is_list(NewOps) ->
     case ets:lookup(?TABLE, TypeName) of
         [#af_type{ops = Ops} = Type] ->
-            UpdatedOps = maps:put(OpName, NewOps, Ops),
+            ExistingList = maps:get(OpName, Ops, []),
+            Preserved = preserve_defined_at(NewOps, ExistingList),
+            UpdatedOps = maps:put(OpName, Preserved, Ops),
             ets:insert(?TABLE, Type#af_type{ops = UpdatedOps}),
             ok;
         [] ->
@@ -132,6 +155,47 @@ get_type(Name) ->
 all_types() ->
     ets:tab2list(?TABLE).
 
+%% Current monotonic counter value. Exposed so tests and tooling can snapshot
+%% the dictionary state to roll back to.
+current_def_counter() ->
+    case ets:lookup(?CTRTAB, counter) of
+        [{counter, N}] -> N;
+        [] -> 0
+    end.
+
+%% Forth-style `forget`: remove every operation named OpName from every type
+%% dictionary, together with every op defined at or after OpName's first
+%% defined_at counter. Types themselves are not forgotten.
+%%
+%% Returns `ok` when at least one op was removed, `{error, not_found}` when
+%% no op with that name exists.
+forget(OpName) when is_list(OpName) ->
+    case find_first_def_counter(OpName) of
+        not_found -> {error, not_found};
+        {ok, C} ->
+            lists:foreach(fun(#af_type{ops = Ops} = Type) ->
+                FilteredOps = maps:map(fun(_K, OpList) ->
+                    [Op || Op <- OpList, keep_op(Op, C)]
+                end, Ops),
+                CleanedOps = maps:filter(fun(_K, V) -> V =/= [] end,
+                                         FilteredOps),
+                ets:insert(?TABLE, Type#af_type{ops = CleanedOps})
+            end, ets:tab2list(?TABLE)),
+            %% Roll the counter back so subsequent definitions reuse slots.
+            case ets:lookup(?CTRTAB, counter) of
+                [{counter, _}] -> ets:insert(?CTRTAB, {counter, C - 1});
+                [] -> ok
+            end,
+            ok
+    end;
+forget(OpName) when is_atom(OpName) ->
+    forget(atom_to_list(OpName));
+forget(OpName) when is_binary(OpName) ->
+    forget(binary_to_list(OpName)).
+
+keep_op(#operation{defined_at = undefined}, _Cutoff) -> true;
+keep_op(#operation{defined_at = At}, Cutoff) -> At < Cutoff.
+
 %%% Internal
 
 ensure_type(Name) ->
@@ -173,6 +237,46 @@ match_guard(#operation{guard = GuardTokens}, Stack) ->
         #continuation{data_stack = [{'Bool', true} | _]} -> true;
         _ -> false
     catch _:_ -> false
+    end.
+
+%% Stamp an op with the next monotonic counter. An op that already carries a
+%% counter (e.g. one carried across replace_ops) keeps it unchanged.
+stamp_op(#operation{defined_at = undefined} = Op) ->
+    Op#operation{defined_at = next_def_counter()};
+stamp_op(Op) -> Op.
+
+%% Allocate the next monotonic counter. ets:update_counter is atomic.
+next_def_counter() ->
+    ets:update_counter(?CTRTAB, counter, 1).
+
+%% Carry defined_at from existing ops onto new ones that lack it.
+preserve_defined_at(NewOps, ExistingOps) ->
+    ExistingCounters = [O#operation.defined_at || O <- ExistingOps,
+                        O#operation.defined_at =/= undefined],
+    {Out, _} = lists:mapfoldl(fun
+        (Op, Acc) when Op#operation.defined_at =/= undefined ->
+            {Op, Acc};
+        (Op, [H | T]) ->
+            {Op#operation{defined_at = H}, T};
+        (Op, []) ->
+            {Op#operation{defined_at = next_def_counter()}, []}
+    end, ExistingCounters, NewOps),
+    Out.
+
+%% Locate the smallest defined_at counter associated with any op named OpName.
+find_first_def_counter(OpName) ->
+    Candidates = lists:foldl(fun(#af_type{ops = Ops}, Acc) ->
+        case maps:get(OpName, Ops, []) of
+            [] -> Acc;
+            OpList ->
+                [Op#operation.defined_at
+                 || Op <- OpList, Op#operation.defined_at =/= undefined]
+                ++ Acc
+        end
+    end, [], ets:tab2list(?TABLE)),
+    case Candidates of
+        [] -> not_found;
+        _ -> {ok, lists:min(Candidates)}
     end.
 
 %%% ============================================================

--- a/src/af_type_any.erl
+++ b/src/af_type_any.erl
@@ -177,6 +177,12 @@ init() ->
         handler = fun handle_debug/2
     }),
 
+    %% forget : String ->  (remove named word plus everything defined after it)
+    af_type:add_op('Any', #operation{
+        name = "forget", sig_in = ['String'], sig_out = [],
+        impl = fun op_forget/1
+    }),
+
     ok.
 
 get_ops(TypeName) ->
@@ -548,6 +554,20 @@ group_defs_by_type(WordDefs) ->
 op_auto_compile(Cont) ->
     [{'Bool', Flag} | Rest] = Cont#continuation.data_stack,
     persistent_term:put(af_auto_compile, Flag),
+    Cont#continuation{data_stack = Rest}.
+
+%% forget <name-as-string>: Forth-style dictionary rollback.
+op_forget(Cont) ->
+    [{'String', Name} | Rest] = Cont#continuation.data_stack,
+    NameStr = case Name of
+        B when is_binary(B) -> binary_to_list(B);
+        L when is_list(L) -> L
+    end,
+    case af_type:forget(NameStr) of
+        ok -> ok;
+        {error, not_found} ->
+            io:format("forget: word '~s' is not defined~n", [NameStr])
+    end,
     Cont#continuation{data_stack = Rest}.
 
 %% Called by af_type_compiler after word registration when auto-compile is enabled.

--- a/test/af_forget_tests.erl
+++ b/test/af_forget_tests.erl
@@ -1,0 +1,239 @@
+-module(af_forget_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("token.hrl").
+-include("continuation.hrl").
+-include("operation.hrl").
+-include("af_type.hrl").
+
+setup() ->
+    af_type:reset().
+
+eval(Input) ->
+    Tokens = af_parser:parse(Input, "test"),
+    af_interpreter:interpret_tokens(Tokens, af_interpreter:new_continuation()).
+
+%%====================================================================
+%% defined_at stamping
+%%====================================================================
+
+defined_at_test_() ->
+    {foreach, fun setup/0, fun(_) -> ok end, [
+        fun(_) -> {"new op receives a defined_at counter", fun() ->
+            _ = eval(": foo Int -> Int ; 1 + ."),
+            {ok, Op} = af_type:find_op_by_name("foo", 'Int'),
+            ?assert(is_integer(Op#operation.defined_at)),
+            ?assert(Op#operation.defined_at > 0)
+        end} end,
+
+        fun(_) -> {"later op has higher defined_at", fun() ->
+            _ = eval(": alpha Int -> Int ; 1 + ."),
+            _ = eval(": beta Int -> Int ; 2 + ."),
+            {ok, A} = af_type:find_op_by_name("alpha", 'Int'),
+            {ok, B} = af_type:find_op_by_name("beta", 'Int'),
+            ?assert(B#operation.defined_at > A#operation.defined_at)
+        end} end,
+
+        fun(_) -> {"current_def_counter increases across definitions", fun() ->
+            Before = af_type:current_def_counter(),
+            _ = eval(": w1 Int -> Int ; 1 + ."),
+            _ = eval(": w2 Int -> Int ; 1 + ."),
+            After = af_type:current_def_counter(),
+            ?assert(After > Before)
+        end} end
+    ]}.
+
+%%====================================================================
+%% forget semantics
+%%====================================================================
+
+forget_basic_test_() ->
+    {foreach, fun setup/0, fun(_) -> ok end, [
+        fun(_) -> {"forget removes the named word", fun() ->
+            _ = eval(": doomed Int -> Int ; 99 + ."),
+            ?assertMatch({ok, _}, af_type:find_op_by_name("doomed", 'Int')),
+            ok = af_type:forget("doomed"),
+            ?assertEqual(not_found,
+                         af_type:find_op_by_name("doomed", 'Int'))
+        end} end,
+
+        fun(_) -> {"forget also removes all later-defined words", fun() ->
+            _ = eval(": survivor Int -> Int ; 1 + ."),
+            _ = eval(": victim   Int -> Int ; 2 + ."),
+            _ = eval(": later    Int -> Int ; 3 + ."),
+            ok = af_type:forget("victim"),
+            ?assertMatch({ok, _}, af_type:find_op_by_name("survivor", 'Int')),
+            ?assertEqual(not_found,
+                         af_type:find_op_by_name("victim", 'Int')),
+            ?assertEqual(not_found,
+                         af_type:find_op_by_name("later", 'Int'))
+        end} end,
+
+        fun(_) -> {"forget returns not_found for unknown name", fun() ->
+            ?assertEqual({error, not_found}, af_type:forget("no-such-word"))
+        end} end,
+
+        fun(_) -> {"forget preserves earlier definitions", fun() ->
+            _ = eval(": early Int -> Int ; 1 + ."),
+            Before = af_type:current_def_counter(),
+            _ = eval(": mid Int -> Int ; 2 + ."),
+            _ = eval(": late Int -> Int ; 3 + ."),
+            ok = af_type:forget("mid"),
+            {ok, Op} = af_type:find_op_by_name("early", 'Int'),
+            ?assert(Op#operation.defined_at =< Before)
+        end} end,
+
+        fun(_) -> {"forget accepts atom names", fun() ->
+            _ = eval(": atom-named Int -> Int ; 1 + ."),
+            ok = af_type:forget('atom-named'),
+            ?assertEqual(not_found,
+                         af_type:find_op_by_name("atom-named", 'Int'))
+        end} end,
+
+        fun(_) -> {"forget accepts binary names", fun() ->
+            _ = eval(": bin-named Int -> Int ; 1 + ."),
+            ok = af_type:forget(<<"bin-named">>),
+            ?assertEqual(not_found,
+                         af_type:find_op_by_name("bin-named", 'Int'))
+        end} end
+    ]}.
+
+forget_rolls_counter_back_test_() ->
+    {foreach, fun setup/0, fun(_) -> ok end, [
+        fun(_) -> {"forget rolls counter back so new definitions reuse slots", fun() ->
+            _ = eval(": first Int -> Int ; 1 + ."),
+            {ok, FirstOp} = af_type:find_op_by_name("first", 'Int'),
+            FirstAt = FirstOp#operation.defined_at,
+
+            _ = eval(": doomed Int -> Int ; 9 + ."),
+            ok = af_type:forget("doomed"),
+
+            _ = eval(": next Int -> Int ; 2 + ."),
+            {ok, NextOp} = af_type:find_op_by_name("next", 'Int'),
+            %% next should have a counter that is at most one greater than
+            %% first's counter (the slot doomed had vacated).
+            ?assert(NextOp#operation.defined_at >= FirstAt),
+            ?assert(NextOp#operation.defined_at =< FirstAt + 2)
+        end} end
+    ]}.
+
+%%====================================================================
+%% `forget` word at the REPL
+%%====================================================================
+
+forget_word_test_() ->
+    {foreach, fun setup/0, fun(_) -> ok end, [
+        fun(_) -> {"forget word removes named word", fun() ->
+            _ = eval(": temp Int -> Int ; 7 + ."),
+            ?assertMatch({ok, _}, af_type:find_op_by_name("temp", 'Int')),
+            _ = eval("\"temp\" forget"),
+            ?assertEqual(not_found,
+                         af_type:find_op_by_name("temp", 'Int'))
+        end} end,
+
+        fun(_) -> {"forget word with unknown name does not crash", fun() ->
+            %% Just verify no exception; the word prints a notice.
+            _ = eval("\"never-defined\" forget"),
+            ok
+        end} end,
+
+        fun(_) -> {"forget word leaves empty stack", fun() ->
+            _ = eval(": temp2 Int -> Int ; 5 + ."),
+            C = eval("\"temp2\" forget"),
+            ?assertEqual([], C#continuation.data_stack)
+        end} end
+    ]}.
+
+%%====================================================================
+%% replace_ops preserves defined_at
+%%====================================================================
+
+replace_preserves_counter_test_() ->
+    {foreach, fun setup/0, fun(_) -> ok end, [
+        fun(_) -> {"replace_ops does not bump the counter", fun() ->
+            _ = eval(": stable Int -> Int ; 1 + ."),
+            {ok, Before} = af_type:find_op_by_name("stable", 'Int'),
+            BeforeAt = Before#operation.defined_at,
+
+            %% Replace with a brand-new op lacking defined_at; the carry-forward
+            %% logic should apply the original's counter.
+            NewOp = #operation{
+                name = "stable", sig_in = ['Int'], sig_out = ['Int'],
+                impl = fun(Cont) -> Cont end
+            },
+            af_type:replace_ops('Int', "stable", [NewOp]),
+
+            {ok, After} = af_type:find_op_by_name("stable", 'Int'),
+            ?assertEqual(BeforeAt, After#operation.defined_at)
+        end} end
+    ]}.
+
+%%====================================================================
+%% stamp_op path: pre-stamped op keeps its counter
+%%====================================================================
+
+pre_stamped_add_op_test_() ->
+    {foreach, fun setup/0, fun(_) -> ok end, [
+        fun(_) -> {"add_op preserves an already-set defined_at", fun() ->
+            Op = #operation{
+                name = "prestamped",
+                sig_in = ['Int'], sig_out = ['Int'],
+                impl = fun(Cont) -> Cont end,
+                defined_at = 42
+            },
+            ok = af_type:add_op('Int', Op),
+            {ok, Got} = af_type:find_op_by_name("prestamped", 'Int'),
+            ?assertEqual(42, Got#operation.defined_at)
+        end} end
+    ]}.
+
+replace_ops_mixed_test_() ->
+    {foreach, fun setup/0, fun(_) -> ok end, [
+        fun(_) -> {"replace_ops with pre-stamped new op keeps its counter", fun() ->
+            _ = eval(": orig Int -> Int ; 1 + ."),
+            NewOp = #operation{
+                name = "orig", sig_in = ['Int'], sig_out = ['Int'],
+                impl = fun(Cont) -> Cont end,
+                defined_at = 999
+            },
+            af_type:replace_ops('Int', "orig", [NewOp]),
+            {ok, Got} = af_type:find_op_by_name("orig", 'Int'),
+            ?assertEqual(999, Got#operation.defined_at)
+        end} end,
+
+        fun(_) -> {"replace_ops with more new ops than existing counters", fun() ->
+            _ = eval(": solo Int -> Int ; 1 + ."),
+            %% Replace with two unstamped ops. First inherits original counter;
+            %% second must allocate a fresh one.
+            Op1 = #operation{name = "solo", sig_in = ['Int'], sig_out = ['Int'],
+                             impl = fun(C) -> C end},
+            Op2 = #operation{name = "solo", sig_in = ['Int'], sig_out = ['Int'],
+                             impl = fun(C) -> C end},
+            af_type:replace_ops('Int', "solo", [Op1, Op2]),
+            {ok, #af_type{ops = Ops}} = af_type:get_type('Int'),
+            [A, B] = maps:get("solo", Ops),
+            ?assert(is_integer(A#operation.defined_at)),
+            ?assert(is_integer(B#operation.defined_at)),
+            ?assert(B#operation.defined_at > A#operation.defined_at)
+        end} end
+    ]}.
+
+%%====================================================================
+%% Built-in primitives are all stamped with counters
+%%====================================================================
+
+builtins_stamped_test_() ->
+    {foreach, fun setup/0, fun(_) -> ok end, [
+        fun(_) -> {"built-in 'dup' has a defined_at counter", fun() ->
+            {ok, Op} = af_type:find_op_by_name("dup", 'Any'),
+            ?assert(is_integer(Op#operation.defined_at))
+        end} end,
+
+        fun(_) -> {"all ops in Any have defined_at", fun() ->
+            {ok, #af_type{ops = Ops}} = af_type:get_type('Any'),
+            Unstamped = maps:fold(fun(_K, OpList, Acc) ->
+                [Op || Op <- OpList, Op#operation.defined_at =:= undefined] ++ Acc
+            end, [], Ops),
+            ?assertEqual([], Unstamped)
+        end} end
+    ]}.


### PR DESCRIPTION
Closes #30.

Adds a monotonic `defined_at` counter to every operation and a Forth-tradition `forget` word for dictionary rollback.

**Deviated from the issue**: the proposed persistent_term migration turned out to be unworkable. persistent_term copies the value into a GC-collected literal heap on every `put`, and the compiler's write-heavy registry blew out literal_alloc during test runs. ETS remains the right storage for this path; the counter gives us the `forget` semantics without changing the hot path. I updated the issue body to explain.

Usage:
```
"my-word" forget
```

**Tests**: 21 new. **Suite**: 2116 passing. **Coverage**: `af_type` 97%.