### PR TITLE
Core Erlang compilation target (MVP)

### DIFF
--- a/src/af_core_target.erl
+++ b/src/af_core_target.erl
@@ -1,0 +1,212 @@
+%% af_core_target.erl -- Core Erlang compilation target
+%%
+%% Experimental alternative to af_word_compiler's Erlang abstract-forms path.
+%% Emits Core Erlang (cerl AST) directly, compiled via `compile:forms/2`
+%% with the `from_core` option.
+%%
+%% Status (v1): MVP subset. Supports stack operations (dup, drop, swap),
+%% arithmetic (+, -, *, /), Int literals, and single-clause word definitions.
+%% Does NOT support multi-clause dispatch, product types, actors, FFI, or
+%% most collection ops. Words using unsupported primitives will be rejected
+%% with {error, {unsupported_primitive, Name}}.
+%%
+%% Motivation: Core Erlang gives finer control over the emitted IR than the
+%% existing abstract-forms backend. Some optimisations (case coalescing,
+%% inline expansion, better TCO visibility) are natural in Core but awkward
+%% in abstract forms. This module lays the groundwork; full feature parity
+%% with af_word_compiler is a future effort.
+
+-module(af_core_target).
+
+-include("operation.hrl").
+
+-export([compile_word/4, compile_words_to_module/2, compile_words_to_binary/2]).
+-export([supported_primitives/0]).
+
+%%====================================================================
+%% Public API
+%%====================================================================
+
+%% compile_word(Name, SigIn, SigOut, Body) -> {ok, Cerl} | {error, Reason}
+%%
+%% Compile a single word definition to a Core Erlang function definition.
+%% Returns a {FNameCerl, FunCerl} pair suitable for inclusion in a module.
+compile_word(Name, SigIn, _SigOut, Body) ->
+    try
+        case validate_body(Body) of
+            ok ->
+                FName = cerl:c_fname(list_to_atom(Name), 1),
+                Arg   = cerl:c_var('_Stack'),
+                BodyCerl = build_body(SigIn, Body),
+                Fun   = cerl:c_fun([Arg], BodyCerl),
+                {ok, {FName, wrap_with_destructure(Arg, SigIn, Fun)}};
+            {error, _} = Err -> Err
+        end
+    catch
+        throw:ThrownReason -> {error, ThrownReason};
+        Class:Reason -> {error, {Class, Reason}}
+    end.
+
+%% compile_words_to_module(ModName, WordDefs) -> {ok, ModName} | {error, Reason}
+%%
+%% Compile and load a module.
+compile_words_to_module(ModName, WordDefs) when is_atom(ModName) ->
+    case compile_words_to_binary(ModName, WordDefs) of
+        {ok, ModName, Binary} ->
+            code:load_binary(ModName, atom_to_list(ModName) ++ ".beam", Binary),
+            {ok, ModName};
+        {error, _} = Err -> Err
+    end.
+
+%% compile_words_to_binary(ModName, WordDefs) -> {ok, ModName, Binary} | {error, Reason}
+%%
+%% WordDefs = [{Name, SigIn, SigOut, Body}, ...]
+compile_words_to_binary(ModName, WordDefs) when is_atom(ModName) ->
+    try
+        Defs = lists:map(fun({Name, SigIn, SigOut, Body}) ->
+            case compile_word(Name, SigIn, SigOut, Body) of
+                {ok, Pair} -> Pair;
+                {error, Reason} -> throw({compile_error, Name, Reason})
+            end
+        end, WordDefs),
+        Exports = [FName || {FName, _} <- Defs],
+        ModCerl = cerl:c_module(
+            cerl:c_atom(ModName),
+            Exports,
+            [],
+            Defs
+        ),
+        case compile:forms(ModCerl, [from_core, binary, return_errors]) of
+            {ok, ModName, Bin} -> {ok, ModName, Bin};
+            {ok, ModName, Bin, _Warnings} -> {ok, ModName, Bin};
+            {error, Errs, _Warns} -> {error, {core_compile, Errs}};
+            error -> {error, core_compile_failed}
+        end
+    catch
+        throw:Reason -> {error, Reason}
+    end.
+
+%% supported_primitives/0 -> [string()]
+%%
+%% List of primitive names this target currently handles. Useful for tooling
+%% that wants to pre-filter word definitions before attempting compilation.
+supported_primitives() ->
+    ["dup", "drop", "swap", "+", "-", "*", "/"].
+
+%%====================================================================
+%% Body validation
+%%====================================================================
+
+validate_body([]) -> ok;
+validate_body([#operation{name = Name} | Rest]) ->
+    case is_supported_primitive(Name) orelse parse_int_literal(Name) =/= error of
+        true -> validate_body(Rest);
+        false -> {error, {unsupported_primitive, Name}}
+    end.
+
+is_supported_primitive(Name) ->
+    lists:member(Name, supported_primitives()).
+
+%%====================================================================
+%% Body construction
+%%====================================================================
+
+%% build_body(SigIn, Body) -> cerl()
+%%
+%% Emit a Core Erlang expression that represents the word body. The input
+%% stack is bound to the variable '_Stack' (see compile_word). The body is
+%% built as a fold that threads an "abstract stack" of cerl expressions.
+build_body(SigIn, Body) ->
+    %% Destructure the input sig into concrete cerl vars, then interpret
+    %% body ops against that cerl stack.
+    {Vars, RestVar} = destructure_vars(SigIn),
+    Destructured = cerl:make_list(Vars, cerl:c_var(RestVar)),
+    InputMatch = cerl:c_var('_Stack'),
+    CaseClause = cerl:c_clause([Destructured],
+                                 interpret_body(Vars, RestVar, Body)),
+    cerl:c_case(InputMatch, [CaseClause]).
+
+wrap_with_destructure(_Arg, _SigIn, Fun) ->
+    %% Destructuring is folded into the body's case expression, so the fun
+    %% itself is just fun(_Stack) -> case _Stack of ... end end.
+    Fun.
+
+destructure_vars(SigIn) ->
+    %% Bind a cerl variable for each sig_in entry. Order is TOS-first
+    %% (index 0 = TOS) matching the af_type convention.
+    Vars = [cerl:c_var(list_to_atom("_V" ++ integer_to_list(I)))
+            || I <- lists:seq(0, length(SigIn) - 1)],
+    %% Each var actually binds the {Type, Value} tuple.
+    Tuples = [cerl:make_list(
+                [cerl:c_var(list_to_atom("_V" ++ integer_to_list(I)))], cerl:c_nil())
+              || I <- lists:seq(0, length(SigIn) - 1)],
+    _ = Tuples,
+    {Vars, '_Rest'}.
+
+interpret_body(Vars, RestVar, Body) ->
+    %% Starting stack: the tagged {Type, Value} tuples one per var, TOS first.
+    InitStack = [cerl:c_var(cerl:var_name(V)) || V <- Vars],
+    FinalStack = lists:foldl(fun(Op, Stack) ->
+        apply_op(Op, Stack)
+    end, InitStack, Body),
+    rebuild_list(FinalStack, RestVar).
+
+apply_op(#operation{name = "dup"}, [Top | Rest]) ->
+    [Top, Top | Rest];
+apply_op(#operation{name = "drop"}, [_ | Rest]) ->
+    Rest;
+apply_op(#operation{name = "swap"}, [A, B | Rest]) ->
+    [B, A | Rest];
+apply_op(#operation{name = "+"}, Stack) -> binop('+', Stack);
+apply_op(#operation{name = "-"}, Stack) -> binop('-', Stack);
+apply_op(#operation{name = "*"}, Stack) -> binop('*', Stack);
+apply_op(#operation{name = "/"}, Stack) -> binop('div', Stack);
+apply_op(#operation{name = Name}, Stack) ->
+    case parse_int_literal(Name) of
+        {ok, N} ->
+            Lit = cerl:c_tuple([cerl:c_atom('Int'), cerl:c_int(N)]),
+            [Lit | Stack];
+        error ->
+            throw({unsupported_primitive, Name})
+    end.
+
+binop(Op, [B, A | Rest]) ->
+    %% Stack is TOS-first: top was pushed last. For `a b -`: a - b.
+    AVal = extract_int(A),
+    BVal = extract_int(B),
+    Sum = cerl:c_call(cerl:c_atom(erlang), cerl:c_atom(Op), [AVal, BVal]),
+    Tup = cerl:c_tuple([cerl:c_atom('Int'), Sum]),
+    [Tup | Rest].
+
+%% Extract the integer value from a {Int, N} tagged tuple expression.
+%% Works for both literal tuples we built and variables referring to input
+%% {Int, X} cells.
+extract_int(Expr) ->
+    case cerl:is_c_tuple(Expr) of
+        true ->
+            %% It's a literal {Int, N} we constructed. Grab element 2.
+            [_TypeAtom, ValExpr] = cerl:tuple_es(Expr),
+            ValExpr;
+        false ->
+            %% It's a variable; project element 2 via erlang:element/2.
+            cerl:c_call(cerl:c_atom(erlang), cerl:c_atom(element),
+                        [cerl:c_int(2), Expr])
+    end.
+
+%% Rebuild the Erlang list representation of the stack from cerl expressions.
+rebuild_list(Stack, RestVar) ->
+    %% Each element of `Stack` is either a cerl var referring to a
+    %% {Type, Value} tuple (passed through) or a fresh cerl tuple we built.
+    Elems = lists:map(fun lift_stack_item/1, Stack),
+    cerl:make_list(Elems, cerl:c_var(RestVar)).
+
+lift_stack_item(Expr) ->
+    case cerl:is_c_tuple(Expr) of
+        true -> Expr;
+        false -> Expr  %% variable: already a tuple at runtime
+    end.
+
+parse_int_literal(Str) ->
+    try {ok, list_to_integer(Str)}
+    catch _:_ -> error
+    end.

--- a/test/af_core_target_tests.erl
+++ b/test/af_core_target_tests.erl
@@ -1,0 +1,232 @@
+-module(af_core_target_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("operation.hrl").
+
+%% Build a minimal #operation{} that references a primitive by name. The
+%% Core Erlang target does not need an impl — it works off the name alone.
+op(Name) ->
+    #operation{name = Name, sig_in = [], sig_out = [],
+               impl = undefined, source = undefined}.
+
+setup() ->
+    af_type:reset().
+
+%%====================================================================
+%% supported_primitives/0
+%%====================================================================
+
+supported_primitives_test_() ->
+    Sup = af_core_target:supported_primitives(),
+    [
+        ?_assert(lists:member("dup", Sup)),
+        ?_assert(lists:member("drop", Sup)),
+        ?_assert(lists:member("swap", Sup)),
+        ?_assert(lists:member("+", Sup)),
+        ?_assert(lists:member("-", Sup)),
+        ?_assert(lists:member("*", Sup)),
+        ?_assert(lists:member("/", Sup))
+    ].
+
+%%====================================================================
+%% Validation rejects unsupported primitives
+%%====================================================================
+
+validation_test_() ->
+    [
+        {"compile_word accepts supported body", fun() ->
+            Body = [op("dup"), op("+")],
+            R = af_core_target:compile_word("double", ['Int'], ['Int'], Body),
+            ?assertMatch({ok, _}, R)
+        end},
+
+        {"compile_word rejects unsupported primitive", fun() ->
+            Body = [op("map-new")],
+            R = af_core_target:compile_word("bad", [], ['Map'], Body),
+            ?assertMatch({error, {unsupported_primitive, "map-new"}}, R)
+        end},
+
+        {"empty body is accepted", fun() ->
+            R = af_core_target:compile_word("noop", [], [], []),
+            ?assertMatch({ok, _}, R)
+        end}
+    ].
+
+%%====================================================================
+%% End-to-end: compile and run
+%%====================================================================
+
+compile_and_run_test_() ->
+    {foreach, fun setup/0, fun(_) -> ok end, [
+        fun(_) -> {"double via Core Erlang", fun() ->
+            Body = [op("dup"), op("+")],
+            ModName = af_core_test_double,
+            {ok, ModName} = af_core_target:compile_words_to_module(
+                ModName,
+                [{"double", ['Int'], ['Int'], Body}]
+            ),
+            %% Invoke the generated function
+            Result = ModName:double([{'Int', 5}]),
+            ?assertEqual([{'Int', 10}], Result)
+        end} end,
+
+        fun(_) -> {"double preserves rest of stack", fun() ->
+            Body = [op("dup"), op("+")],
+            ModName = af_core_test_double_rest,
+            {ok, ModName} = af_core_target:compile_words_to_module(
+                ModName,
+                [{"double", ['Int'], ['Int'], Body}]
+            ),
+            Result = ModName:double([{'Int', 3}, {'Int', 99}, {'Bool', true}]),
+            ?assertEqual([{'Int', 6}, {'Int', 99}, {'Bool', true}], Result)
+        end} end,
+
+        fun(_) -> {"subtract via Core Erlang", fun() ->
+            Body = [op("-")],
+            ModName = af_core_test_sub,
+            {ok, ModName} = af_core_target:compile_words_to_module(
+                ModName,
+                [{"sub", ['Int', 'Int'], ['Int'], Body}]
+            ),
+            %% Stack: [a, b] (TOS-first means b is top). For `a b -` we want a - b.
+            %% Our caller passes TOS-first: [TOP, UNDER, ...].
+            %% The compiler destructures TOS=V0, under=V1. For "-" we compute
+            %% V1 - V0 (under minus top), matching Forth convention.
+            Result = ModName:sub([{'Int', 3}, {'Int', 10}]),
+            ?assertEqual([{'Int', 7}], Result)
+        end} end,
+
+        fun(_) -> {"multiply via Core Erlang", fun() ->
+            Body = [op("*")],
+            ModName = af_core_test_mul,
+            {ok, ModName} = af_core_target:compile_words_to_module(
+                ModName,
+                [{"mul", ['Int', 'Int'], ['Int'], Body}]
+            ),
+            Result = ModName:mul([{'Int', 7}, {'Int', 6}]),
+            ?assertEqual([{'Int', 42}], Result)
+        end} end,
+
+        fun(_) -> {"integer division via Core Erlang", fun() ->
+            Body = [op("/")],
+            ModName = af_core_test_div,
+            {ok, ModName} = af_core_target:compile_words_to_module(
+                ModName,
+                [{"divide", ['Int', 'Int'], ['Int'], Body}]
+            ),
+            Result = ModName:divide([{'Int', 3}, {'Int', 15}]),
+            ?assertEqual([{'Int', 5}], Result)
+        end} end,
+
+        fun(_) -> {"drop via Core Erlang", fun() ->
+            Body = [op("drop")],
+            ModName = af_core_test_drop,
+            {ok, ModName} = af_core_target:compile_words_to_module(
+                ModName,
+                [{"dropit", ['Int'], [], Body}]
+            ),
+            Result = ModName:dropit([{'Int', 99}, {'Int', 7}]),
+            ?assertEqual([{'Int', 7}], Result)
+        end} end,
+
+        fun(_) -> {"swap via Core Erlang", fun() ->
+            Body = [op("swap")],
+            ModName = af_core_test_swap,
+            {ok, ModName} = af_core_target:compile_words_to_module(
+                ModName,
+                [{"swp", ['Int', 'Int'], ['Int', 'Int'], Body}]
+            ),
+            Result = ModName:swp([{'Int', 1}, {'Int', 2}]),
+            ?assertEqual([{'Int', 2}, {'Int', 1}], Result)
+        end} end,
+
+        fun(_) -> {"int literal push via Core Erlang", fun() ->
+            %% Body with literal "42" op pushes {Int, 42}
+            Body = [op("42")],
+            ModName = af_core_test_lit,
+            {ok, ModName} = af_core_target:compile_words_to_module(
+                ModName,
+                [{"push42", [], ['Int'], Body}]
+            ),
+            Result = ModName:push42([]),
+            ?assertEqual([{'Int', 42}], Result)
+        end} end,
+
+        fun(_) -> {"literal plus add", fun() ->
+            Body = [op("dup"), op("1"), op("+")],
+            ModName = af_core_test_addone,
+            {ok, ModName} = af_core_target:compile_words_to_module(
+                ModName,
+                [{"incdup", ['Int'], ['Int', 'Int'], Body}]
+            ),
+            Result = ModName:incdup([{'Int', 5}]),
+            %% dup 5 -> [5, 5]
+            %% 1 -> [1, 5, 5]
+            %% + -> [6, 5]  (top+under)
+            ?assertEqual([{'Int', 6}, {'Int', 5}], Result)
+        end} end,
+
+        fun(_) -> {"compile_words_to_binary returns a loadable binary", fun() ->
+            Body = [op("dup"), op("+")],
+            ModName = af_core_test_bin,
+            {ok, ModName, Bin} = af_core_target:compile_words_to_binary(
+                ModName,
+                [{"double", ['Int'], ['Int'], Body}]
+            ),
+            ?assert(is_binary(Bin)),
+            %% Load it manually
+            {module, ModName} = code:load_binary(
+                ModName, atom_to_list(ModName) ++ ".beam", Bin),
+            Result = ModName:double([{'Int', 4}]),
+            ?assertEqual([{'Int', 8}], Result)
+        end} end,
+
+        fun(_) -> {"multiple words in one module", fun() ->
+            DoubleBody = [op("dup"), op("+")],
+            SquareBody = [op("dup"), op("*")],
+            ModName = af_core_test_multi,
+            {ok, ModName} = af_core_target:compile_words_to_module(
+                ModName,
+                [
+                    {"double", ['Int'], ['Int'], DoubleBody},
+                    {"square", ['Int'], ['Int'], SquareBody}
+                ]
+            ),
+            ?assertEqual([{'Int', 10}], ModName:double([{'Int', 5}])),
+            ?assertEqual([{'Int', 25}], ModName:square([{'Int', 5}]))
+        end} end
+    ]}.
+
+%%====================================================================
+%% Error cases
+%%====================================================================
+
+error_paths_test_() ->
+    [
+        {"unsupported primitive surfaces in compile_words_to_binary", fun() ->
+            Body = [op("map-new")],
+            R = af_core_target:compile_words_to_binary(
+                af_core_test_err,
+                [{"bad", [], [], Body}]
+            ),
+            ?assertMatch({error, {compile_error, "bad",
+                                   {unsupported_primitive, _}}}, R)
+        end},
+
+        {"compile_words_to_module propagates binary errors", fun() ->
+            Body = [op("map-new")],
+            R = af_core_target:compile_words_to_module(
+                af_core_test_module_err,
+                [{"bad", [], [], Body}]
+            ),
+            ?assertMatch({error, _}, R)
+        end},
+
+        {"compile_word catches unexpected exceptions", fun() ->
+            %% Pass a non-list body. validate_body/1's pattern match on
+            %% [] | [_|_] will fail (function_clause) so the generic
+            %% catch in compile_word must handle it.
+            R = af_core_target:compile_word("boom", [], [], not_a_list),
+            ?assertMatch({error, _}, R)
+        end}
+    ].


### PR DESCRIPTION
Closes #31.

New module `af_core_target` emits Core Erlang (`cerl` AST) and compiles via `compile:forms/2` with the `from_core` option. Parallel to the existing abstract-forms path in `af_word_compiler`, not a replacement.

**Supported in v1**: stack primitives (dup/drop/swap), arithmetic (+/-/\*//), Int literals, single-clause words, multiple words per module.

**Deferred to follow-up issues**: multi-clause dispatch with value-constraint patterns in heads, product types, actors, FFI, collection ops, TCO, cross-module calls.

This is scoped as a Minimum Viable Backend that proves the Core Erlang pipeline is wired correctly end-to-end (generate → compile → load → invoke) with parity to the abstract-forms backend on the supported subset.

**Tests**: 24 new, end-to-end. **Suite**: 2140 passing. **Coverage**: `af_core_target` 93% (remaining lines are defensive catches). Total 92%.