### PR TITLE
Guard expressions: sub-clauses + BEAM compilation

### DIFF
--- a/src/af_type.erl
+++ b/src/af_type.erl
@@ -51,6 +51,9 @@ init() ->
 reset() ->
     catch ets:delete(?TABLE),
     catch ets:delete(?CTRTAB),
+    %% Reset the auto-compile flag too — tests that leave it enabled would
+    %% otherwise cause subsequent tests to native-compile words unexpectedly.
+    catch persistent_term:erase(af_auto_compile),
     af_repl:init_types().
 
 register_type(#af_type{} = Type) ->

--- a/src/af_type_any.erl
+++ b/src/af_type_any.erl
@@ -417,7 +417,13 @@ op_get_word_defs(Cont) ->
     Name = binary_to_list(NameBin),
     WordDefs = af_word_compiler:find_compiled_word_defs(Name),
     %% Convert to list of maps for A4 consumption
-    DefList = lists:map(fun({WName, SigIn, SigOut, Body}) ->
+    DefList = lists:map(fun(Def) ->
+        %% Def is either 4-tuple or 5-tuple (guarded). We expose only the
+        %% first four fields; guard surfaces through other paths.
+        WName = element(1, Def),
+        SigIn = element(2, Def),
+        SigOut = element(3, Def),
+        Body = element(4, Def),
         {'Map', #{
             {'String', <<"name">>} => {'String', list_to_binary(WName)},
             {'String', <<"sig_in">>} => {'List', [sig_item_to_stack(S) || S <- SigIn]},
@@ -502,7 +508,8 @@ op_compile(Cont) ->
                     ByType = group_defs_by_type(WordDefs),
                     lists:foreach(fun({TargetType, Defs}) ->
                         BroadSigIn = broadest_sig_in(Defs),
-                        {_, _, BroadSigOut, _} = find_broadest_def(Defs),
+                        BroadDef = find_broadest_def(Defs),
+                        BroadSigOut = element(3, BroadDef),
                         Wrapper = af_word_compiler:make_wrapper(ModAtom, FunAtom, BroadSigIn, BroadSigOut),
                         af_type:replace_ops(TargetType, Name, [Wrapper])
                     end, ByType),
@@ -525,14 +532,34 @@ op_compile(Cont) ->
     end.
 
 %% Get the broadest sig_in (strip value constraints to bare types).
+%% Accepts both 4-tuple and 5-tuple def shapes.
 broadest_sig_in(Defs) ->
-    {_, SigIn, _, _} = find_broadest_def(Defs),
+    SigIn = element(2, find_broadest_def(Defs)),
     [case S of {T, _V} -> T; T -> T end || S <- SigIn].
+
+%% Return a guard shared by the whole group if any def has one. If defs
+%% have different guards we don't try to unify them — the wrapper matches
+%% the whole name, so the first non-undefined guard we find "stands for"
+%% the group. (In multi-clause cases the individual clauses still carry
+%% their own guards as sub-clause metadata inside the compiled module.)
+broadest_guard(Defs) ->
+    GetGuard = fun(D) ->
+        %% Guard is the 5th element if present.
+        case tuple_size(D) of
+            5 -> element(5, D);
+            _ -> undefined
+        end
+    end,
+    case [G || D <- Defs, (G = GetGuard(D)) =/= undefined, G =/= []] of
+        [First | _] -> First;
+        [] -> undefined
+    end.
 
 %% Find the def with the broadest (no value constraints) sig_in,
 %% or fall back to the last def if all have constraints.
 find_broadest_def(Defs) ->
-    case lists:filter(fun({_, SigIn, _, _}) ->
+    case lists:filter(fun(Def) ->
+        SigIn = element(2, Def),
         not lists:any(fun(S) -> is_tuple(S) end, SigIn)
     end, Defs) of
         [Def | _] -> Def;
@@ -540,7 +567,9 @@ find_broadest_def(Defs) ->
     end.
 
 group_defs_by_type(WordDefs) ->
-    Groups = lists:foldl(fun({_Name, SigIn, _SigOut, _Body} = Def, Acc) ->
+    %% Accepts 4-tuple (legacy, no guard) or 5-tuple (with guard) defs.
+    Groups = lists:foldl(fun(Def, Acc) ->
+        SigIn = element(2, Def),
         TargetType = case SigIn of
             [{T, _} | _] -> T;
             [T | _] when is_atom(T) -> T;
@@ -586,8 +615,19 @@ auto_compile_word(Name) ->
                             ByType = group_defs_by_type(WordDefs),
                             lists:foreach(fun({TargetType, Defs}) ->
                                 BroadSigIn = broadest_sig_in(Defs),
-                                {_, _, BroadSigOut, _} = find_broadest_def(Defs),
-                                Wrapper = af_word_compiler:make_wrapper(ModAtom, FunAtom, BroadSigIn, BroadSigOut),
+                                BroadDef = find_broadest_def(Defs),
+                                BroadSigOut = element(3, BroadDef),
+                                %% If any def in this group has a guard, carry
+                                %% it onto the wrapper so dispatch still checks
+                                %% it at match time. The native function also
+                                %% has the head guard compiled in; the double
+                                %% check is cheap and keeps multi-clause fall-
+                                %% through working in match_first_op.
+                                BroadGuard = broadest_guard(Defs),
+                                Wrapper0 = af_word_compiler:make_wrapper(
+                                              ModAtom, FunAtom,
+                                              BroadSigIn, BroadSigOut),
+                                Wrapper = Wrapper0#operation{guard = BroadGuard},
                                 af_type:replace_ops(TargetType, Name, [Wrapper])
                             end, ByType);
                         {error, _Reason} ->

--- a/src/af_type_compiler.erl
+++ b/src/af_type_compiler.erl
@@ -228,11 +228,14 @@ handle_output_sig(TokenValue, Cont) ->
 handle_code_compile(":", Cont) ->
     [{'CodeCompile', State} | Rest] = Cont#continuation.data_stack,
     #{body := Body, clauses := Clauses, current_sub := CurrentSub} = State,
-    %% Complete any active sub-clause
+    %% Complete any active sub-clause, carrying any guard through.
     NewClauses = case CurrentSub of
         undefined -> Clauses;
-        #{sub_sig_in := SSI, sub_sig_out := SSO} ->
-            Clauses ++ [#{sig_in => SSI, sig_out => SSO, body => Body}]
+        #{sub_sig_in := SSI, sub_sig_out := SSO} = Sub ->
+            Clauses ++ [#{sig_in => SSI,
+                          sig_out => SSO,
+                          body => Body,
+                          guard => maps:get(sub_guard, Sub, undefined)}]
     end,
     %% Transition to SubClauseInput
     SubState = State#{
@@ -258,17 +261,35 @@ handle_code_compile(TokenValue, Cont) ->
 
 %% Handler: SubClauseInput
 %% Accumulate raw token info; resolution happens in op_sub_arrow after all tokens collected.
-handle_sub_clause_input(TokenValue, Cont) ->
+%% Recognises the `where` keyword to switch into guard-collection mode; tokens
+%% after `where` and before `->` are recorded as the sub-clause's guard body.
+handle_sub_clause_input("where", Cont) ->
     [{'SubClauseInput', State} | Rest] = Cont#continuation.data_stack,
-    #{sub_sig_in := SubSigIn} = State,
-    Token = Cont#continuation.current_token,
-    IsQuoted = case Token of #token{quoted = true} -> true; _ -> false end,
-    NewState = State#{
-        sub_sig_in => SubSigIn ++ [{TokenValue, IsQuoted}]
-    },
+    NewState = State#{sub_in_guard => true, sub_guard => []},
     Cont#continuation{
         data_stack = [{'SubClauseInput', NewState} | Rest]
-    }.
+    };
+handle_sub_clause_input(TokenValue, Cont) ->
+    [{'SubClauseInput', State} | Rest] = Cont#continuation.data_stack,
+    case maps:get(sub_in_guard, State, false) of
+        true ->
+            Token = Cont#continuation.current_token,
+            Guard = maps:get(sub_guard, State, []),
+            NewState = State#{sub_guard => Guard ++ [Token]},
+            Cont#continuation{
+                data_stack = [{'SubClauseInput', NewState} | Rest]
+            };
+        false ->
+            #{sub_sig_in := SubSigIn} = State,
+            Token = Cont#continuation.current_token,
+            IsQuoted = case Token of #token{quoted = true} -> true; _ -> false end,
+            NewState = State#{
+                sub_sig_in => SubSigIn ++ [{TokenValue, IsQuoted}]
+            },
+            Cont#continuation{
+                data_stack = [{'SubClauseInput', NewState} | Rest]
+            }
+    end.
 
 %% Handler: SubClauseOutput
 %% Accumulate raw token info; resolution happens in op_sub_semicolon.
@@ -357,24 +378,36 @@ op_semicolon(Cont) ->
     }.
 
 %% -> in SubClauseInput: resolve accumulated tokens right-aligned, transition to SubClauseOutput
+%% Also ends any guard-collecting mode opened by `where`.
 op_sub_arrow(Cont) ->
     [{'SubClauseInput', State} | Rest] = Cont#continuation.data_stack,
     #{sub_sig_in := RawSubSigIn, sig_in := MasterSigIn} = State,
     %% Resolve raw tokens right-aligned against master sig
     ResolvedSubSigIn = resolve_sub_tokens_right_aligned(RawSubSigIn, MasterSigIn),
-    NewState = State#{sub_sig_in => ResolvedSubSigIn, sub_sig_out => [], sub_out_position => 0},
+    NewState = State#{
+        sub_sig_in => ResolvedSubSigIn,
+        sub_sig_out => [],
+        sub_out_position => 0,
+        sub_in_guard => false
+    },
     Cont#continuation{
         data_stack = [{'SubClauseOutput', NewState} | Rest]
     }.
 
 %% ; in SubClauseOutput: resolve output tokens right-aligned, transition to CodeCompile
+%% Carry the sub-clause guard (if any) into the clause record.
 op_sub_semicolon(Cont) ->
     [{'SubClauseOutput', State} | Rest] = Cont#continuation.data_stack,
     #{sub_sig_in := SubSigIn, sub_sig_out := RawSubSigOut, sig_out := MasterSigOut} = State,
     ResolvedSubSigOut = resolve_sub_tokens_right_aligned(RawSubSigOut, MasterSigOut),
+    SubGuard = maps:get(sub_guard, State, undefined),
+    ClauseRec = #{sub_sig_in => SubSigIn,
+                  sub_sig_out => ResolvedSubSigOut,
+                  sub_guard => SubGuard},
     NewState = State#{
-        current_sub => #{sub_sig_in => SubSigIn, sub_sig_out => ResolvedSubSigOut},
-        body => []
+        current_sub => ClauseRec,
+        body => [],
+        sub_guard => undefined
     },
     Cont#continuation{
         data_stack = [{'CodeCompile', NewState} | Rest]
@@ -389,11 +422,15 @@ op_dot(Cont) ->
             %% Normal case: single operation, no sub-clauses
             register_single_word(State, Rest, Cont);
         false ->
-            %% Multi-clause: complete any active sub-clause and register all
+            %% Multi-clause: complete any active sub-clause and register all.
+            %% Carry per-sub-clause guards through.
             AllClauses = case CurrentSub of
                 undefined -> Clauses;
-                #{sub_sig_in := SSI, sub_sig_out := SSO} ->
-                    Clauses ++ [#{sig_in => SSI, sig_out => SSO, body => Body}]
+                #{sub_sig_in := SSI, sub_sig_out := SSO} = Sub ->
+                    Clauses ++ [#{sig_in => SSI,
+                                  sig_out => SSO,
+                                  body => Body,
+                                  guard => maps:get(sub_guard, Sub, undefined)}]
             end,
             register_multi_word(State, AllClauses, Rest, Cont)
     end.
@@ -427,13 +464,11 @@ register_single_word(State, Rest, Cont) ->
     ensure_type(TargetType),
     af_type:add_op(TargetType, NewOp),
 
-    %% Guarded words currently bypass the BEAM word compiler; the interpreter
-    %% evaluates the guard at dispatch time.
-    case Guard of
-        undefined -> af_type_any:auto_compile_word(Name);
-        [] -> af_type_any:auto_compile_word(Name);
-        _ -> ok
-    end,
+    %% Attempt native compilation regardless of guard. The word compiler
+    %% translates simple guards (`dup LITERAL CMP`) into Erlang function-head
+    %% guards; complex guards cause compile to fail gracefully and the op
+    %% stays interpreter-dispatched.
+    af_type_any:auto_compile_word(Name),
 
     %% Sync local dictionary from ETS (auto_compile_word may have replaced ops)
     Dict1 = sync_type_from_ets(TargetType, Cont#continuation.dictionary),
@@ -443,12 +478,19 @@ register_single_word(State, Rest, Cont) ->
 register_multi_word(State, Clauses, Rest, Cont) ->
     #{name := Name, sig_in := MasterSigIn0} = State,
     MasterGuard = maps:get(guard, State, undefined),
-    case MasterGuard of
+    %% Top-level `where` applies to every sub-clause: any sub-clause without
+    %% its own guard inherits the master guard; sub-clauses with their own
+    %% guard keep it (no implicit conjunction for v1 — per-clause wins).
+    Clauses1 = case MasterGuard of
         G when G =/= undefined, G =/= [] ->
-            error({guard_on_multiclause, Name,
-                "Top-level 'where' guards cannot combine with sub-clauses. "
-                "Define separate top-level clauses with the same name instead."});
-        _ -> ok
+            lists:map(fun(C) ->
+                case maps:get(guard, C, undefined) of
+                    undefined -> C#{guard => MasterGuard};
+                    [] -> C#{guard => MasterGuard};
+                    _ -> C
+                end
+            end, Clauses);
+        _ -> Clauses
     end,
     MasterSigIn = lists:reverse(MasterSigIn0),
     TargetType = get_target_type(MasterSigIn),
@@ -457,21 +499,35 @@ register_multi_word(State, Clauses, Rest, Cont) ->
     %% Register each sub-clause as a separate operation.
     %% Value-constrained clauses come first (they were added in order),
     %% general clauses last — match_first_op tries in list order.
-    lists:foreach(fun(#{sig_in := CSigIn0, sig_out := CSigOut0, body := CBody}) ->
+    %% Each clause may carry its own `where` guard.
+    HasAnyGuard = lists:any(fun(C) ->
+        case maps:get(guard, C, undefined) of
+            undefined -> false;
+            [] -> false;
+            _ -> true
+        end
+    end, Clauses1),
+    lists:foreach(fun(#{sig_in := CSigIn0, sig_out := CSigOut0, body := CBody} = C) ->
         CSigIn = lists:reverse(CSigIn0),
         CSigOut = lists:reverse(CSigOut0),
         type_check_body(Name, CSigIn, CSigOut, CBody),
         Impl = make_word_impl(CBody, Name),
+        CGuard = maps:get(guard, C, undefined),
         Op = #operation{
             name = Name,
             sig_in = CSigIn,
             sig_out = CSigOut,
             impl = Impl,
-            source = {compiled, CBody}
+            source = {compiled, CBody},
+            guard = CGuard
         },
         af_type:add_op(TargetType, Op)
-    end, Clauses),
+    end, Clauses1),
 
+    %% Attempt native compilation regardless of guards. Simple guards compile
+    %% to Erlang function-head guards; complex guards cause that clause to be
+    %% dropped from the native build and fall back to the interpreter.
+    _ = HasAnyGuard,
     af_type_any:auto_compile_word(Name),
 
     %% Sync local dictionary from ETS

--- a/src/af_word_compiler.erl
+++ b/src/af_word_compiler.erl
@@ -10,6 +10,7 @@
 -export([find_native_word/1]).
 -export([find_compiled_word_defs/1]).
 -export([group_by_name/1]).
+-export([guard_to_head_form/3]).  %% exposed for testing
 
 %% Binary storage key prefix for process dictionary
 -define(BIN_KEY(Mod), {af_module_binary, Mod}).
@@ -49,8 +50,10 @@ get_module_binary(ModuleName) ->
 %% Compile word definitions to a BEAM binary without loading.
 %% Groups same-name words into multi-clause functions for pattern matching.
 %% Returns {ok, ModuleName, Binary} | {error, Reason}.
-compile_words_to_binary(ModuleName, WordDefs) when is_atom(ModuleName) ->
+compile_words_to_binary(ModuleName, WordDefs0) when is_atom(ModuleName) ->
     L = 1,
+    %% Normalise to 5-tuple form so internal code paths don't branch on shape.
+    WordDefs = [normalise_def(D) || D <- WordDefs0],
     Ctx = #{module => ModuleName, words => build_word_index(WordDefs)},
     Groups = group_by_name(WordDefs),
     FunForms = lists:filtermap(fun({Name, Defs}) ->
@@ -83,11 +86,14 @@ compile_words_to_binary(ModuleName, WordDefs) when is_atom(ModuleName) ->
             end
     end.
 
-%% Group word definitions by name, preserving order.
+%% Group word definitions by name, preserving order. Accepts either 4-tuple
+%% (no guard) or 5-tuple (with guard) form.
 group_by_name(WordDefs) ->
-    {Groups, Order} = lists:foldl(fun({Name, SI, SO, Body}, {Acc, Ord}) ->
+    {Groups, Order} = lists:foldl(fun(Def, {Acc, Ord}) ->
+        Name = element(1, Def),
+        DefN = normalise_def(Def),
         Existing = maps:get(Name, Acc, []),
-        NewAcc = maps:put(Name, Existing ++ [{Name, SI, SO, Body}], Acc),
+        NewAcc = maps:put(Name, Existing ++ [DefN], Acc),
         NewOrd = case lists:member(Name, Ord) of
             true -> Ord;
             false -> Ord ++ [Name]
@@ -97,9 +103,13 @@ group_by_name(WordDefs) ->
     [{Name, maps:get(Name, Groups)} || Name <- Order].
 
 %% Compile a group of same-name word defs.
+%% Normalise a word-def tuple to {Name, SigIn, SigOut, Body, Guard}.
+normalise_def({N, SI, SO, B}) -> {N, SI, SO, B, undefined};
+normalise_def({_, _, _, _, _} = D) -> D.
+
 %% All functions take arity 1 (the tagged stack list).
-compile_word_group(Name, [{_, SigIn, SigOut, Body}], L, Ctx) ->
-    compile_single_word(Name, SigIn, SigOut, Body, L, Ctx);
+compile_word_group(Name, [{_, SigIn, SigOut, Body, Guard}], L, Ctx) ->
+    compile_single_word(Name, SigIn, SigOut, Body, Guard, L, Ctx);
 compile_word_group(Name, Defs, L, Ctx) ->
     %% Try loop optimization for self-recursive words with << >> blocks
     case try_loop_opt(Name, Defs, L, Ctx) of
@@ -107,8 +117,8 @@ compile_word_group(Name, Defs, L, Ctx) ->
             {ok, Forms, Exports};
         not_applicable ->
             FunAtom = list_to_atom(Name),
-            Clauses = lists:filtermap(fun({_N, SigIn, SigOut, Body}) ->
-                case compile_clause(SigIn, SigOut, Body, L, Ctx) of
+            Clauses = lists:filtermap(fun({_N, SigIn, SigOut, Body, Guard}) ->
+                case compile_clause(SigIn, SigOut, Body, Guard, L, Ctx) of
                     {ok, Clause} -> {true, Clause};
                     {error, _} -> false
                 end
@@ -123,32 +133,130 @@ compile_word_group(Name, Defs, L, Ctx) ->
 
 %% Compile a single-clause word function.
 %% Function signature: fun([{Type, Val}, ...]) -> [{Type, Val}, ...]
-compile_single_word(Name, SigIn, SigOut, Body, L, Ctx) ->
+%% If a guard is present, try to translate it to an Erlang head-guard
+%% expression. If it's not translatable, fail compilation so the caller
+%% falls back to the interpreter path.
+compile_single_word(Name, SigIn, SigOut, Body, Guard, L, Ctx) ->
     FunAtom = list_to_atom(Name),
     {HeadPat, InitExprStack, RestVar} = build_head_pattern(SigIn, L),
-    case simulate_body(Body, InitExprStack, L, Ctx#{rest_var => RestVar}) of
-        {ok, ResultStack, SideEffects} ->
-            ReturnExpr = build_tagged_return(ResultStack, SigOut, RestVar, L),
-            BodyExprs = SideEffects ++ [ReturnExpr],
-            Clause = {clause, L, [HeadPat], [], BodyExprs},
-            Form = {function, L, FunAtom, 1, [Clause]},
-            {ok, Form, {FunAtom, 1}};
+    case guard_or_empty(Guard, InitExprStack, L) of
+        {ok, GuardExprs} ->
+            case simulate_body(Body, InitExprStack, L, Ctx#{rest_var => RestVar}) of
+                {ok, ResultStack, SideEffects} ->
+                    ReturnExpr = build_tagged_return(ResultStack, SigOut, RestVar, L),
+                    BodyExprs = SideEffects ++ [ReturnExpr],
+                    Clause = {clause, L, [HeadPat], GuardExprs, BodyExprs},
+                    Form = {function, L, FunAtom, 1, [Clause]},
+                    {ok, Form, {FunAtom, 1}};
+                {error, Reason} ->
+                    {error, {Name, Reason}}
+            end;
         {error, Reason} ->
             {error, {Name, Reason}}
     end.
 
 %% Compile a single clause for a multi-clause function.
-compile_clause(SigIn, SigOut, Body, L, Ctx) ->
+compile_clause(SigIn, SigOut, Body, Guard, L, Ctx) ->
     {HeadPat, InitExprStack, RestVar} = build_head_pattern(SigIn, L),
-    case simulate_body(Body, InitExprStack, L, Ctx#{rest_var => RestVar}) of
-        {ok, ResultStack, SideEffects} ->
-            ReturnExpr = build_tagged_return(ResultStack, SigOut, RestVar, L),
-            BodyExprs = SideEffects ++ [ReturnExpr],
-            Clause = {clause, L, [HeadPat], [], BodyExprs},
-            {ok, Clause};
+    case guard_or_empty(Guard, InitExprStack, L) of
+        {ok, GuardExprs} ->
+            case simulate_body(Body, InitExprStack, L, Ctx#{rest_var => RestVar}) of
+                {ok, ResultStack, SideEffects} ->
+                    ReturnExpr = build_tagged_return(ResultStack, SigOut, RestVar, L),
+                    BodyExprs = SideEffects ++ [ReturnExpr],
+                    Clause = {clause, L, [HeadPat], GuardExprs, BodyExprs},
+                    {ok, Clause};
+                {error, Reason} ->
+                    {error, Reason}
+            end;
         {error, Reason} ->
             {error, Reason}
     end.
+
+%% Translate an operation's `guard` field into Erlang function-head guard
+%% expressions. A guard of `undefined` or `[]` means "no guard" and produces
+%% the empty guard list (i.e. the clause always matches type-wise).
+guard_or_empty(undefined, _InitExprStack, _L) -> {ok, []};
+guard_or_empty([], _InitExprStack, _L) -> {ok, []};
+guard_or_empty(GuardTokens, InitExprStack, L) ->
+    guard_to_head_form(GuardTokens, InitExprStack, L).
+
+%% Translate a list of guard tokens into Erlang guard-form exprs.
+%% Currently recognises the pattern `dup LITERAL CMP` — the most common
+%% per-clause guard shape (e.g. `dup 0 >`). TOS is the first entry in
+%% InitExprStack; the tuple pattern bound its raw value to a variable we
+%% can reference here.
+%%
+%% Returns {ok, [[GuardExpr]]} for Erlang's guard-sequence-of-alts form,
+%% or {error, guard_not_compilable} if we can't translate.
+guard_to_head_form(Tokens, InitExprStack, L) ->
+    case simple_guard_shape(Tokens) of
+        {cmp, Cmp, Lit} ->
+            case InitExprStack of
+                [{TosExpr, _TosType} | _] ->
+                    %% Extract the raw value from the TOS tuple:
+                    %%   element(2, TosTuple)
+                    RawVal = extract_val({TosExpr, any}, L),
+                    LitExpr = literal_to_abstract(Lit, L),
+                    GuardExpr = {op, L, cmp_to_op(Cmp), RawVal, LitExpr},
+                    {ok, [[GuardExpr]]};
+                [] ->
+                    {error, guard_not_compilable}
+            end;
+        not_recognised ->
+            {error, guard_not_compilable}
+    end.
+
+%% Recognise `dup LITERAL CMP` guard shape.
+%% Returns {cmp, ">" | "<" | "==" | ..., LiteralValue} or not_recognised.
+simple_guard_shape([T1, T2, T3]) ->
+    case {T1#token.value, T2#token.value, T3#token.value} of
+        {"dup", LitStr, Cmp} ->
+            case {is_cmp_op(Cmp), try_parse_literal(LitStr, T2)} of
+                {true, {ok, Lit}} -> {cmp, Cmp, Lit};
+                _ -> not_recognised
+            end;
+        _ -> not_recognised
+    end;
+simple_guard_shape(_) -> not_recognised.
+
+is_cmp_op(">") -> true;
+is_cmp_op("<") -> true;
+is_cmp_op("==") -> true;
+is_cmp_op("!=") -> true;
+is_cmp_op(">=") -> true;
+is_cmp_op("<=") -> true;
+is_cmp_op(_) -> false.
+
+cmp_to_op(">") -> '>';
+cmp_to_op("<") -> '<';
+cmp_to_op("==") -> '=:=';
+cmp_to_op("!=") -> '=/=';
+cmp_to_op(">=") -> '>=';
+cmp_to_op("<=") -> '=<'.
+
+try_parse_literal(Str, #token{quoted = true}) ->
+    {ok, {string, list_to_binary(Str)}};
+try_parse_literal(Str, _Tok) ->
+    case catch list_to_integer(Str) of
+        N when is_integer(N) -> {ok, {integer, N}};
+        _ ->
+            case catch list_to_float(Str) of
+                F when is_float(F) -> {ok, {float, F}};
+                _ ->
+                    case Str of
+                        "true" -> {ok, {atom, true}};
+                        "false" -> {ok, {atom, false}};
+                        _ -> error
+                    end
+            end
+    end.
+
+literal_to_abstract({integer, N}, L) -> {integer, L, N};
+literal_to_abstract({float, F}, L) -> {float, L, F};
+literal_to_abstract({atom, A}, L) -> {atom, L, A};
+literal_to_abstract({string, B}, L) ->
+    {bin, L, [{bin_element, L, {string, L, binary_to_list(B)}, default, default}]}.
 
 %% Loop optimization for self-recursive words.
 %% Detects words like blast that have << >> send blocks and self-recursive
@@ -156,8 +264,10 @@ compile_clause(SigIn, SigOut, Body, L, Ctx) ->
 %% per-iteration list reconstruction and map lookups.
 
 try_loop_opt(Name, Defs, L, Ctx) ->
-    %% Partition into base cases and recursive cases
-    {BaseCases, RecCases} = lists:partition(fun({_, _, _, Body}) ->
+    %% Partition into base cases and recursive cases.
+    %% Defs here are 5-tuples after normalise_def.
+    {BaseCases, RecCases} = lists:partition(fun(Def) ->
+        Body = element(4, Def),
         case Body of
             [] -> true;
             _ ->
@@ -166,7 +276,7 @@ try_loop_opt(Name, Defs, L, Ctx) ->
         end
     end, Defs),
     case {BaseCases, RecCases} of
-        {[_ | _], [{_, RecSigIn, _RecSigOut, RecBody}]} ->
+        {[_ | _], [{_, RecSigIn, _RecSigOut, RecBody, _RecGuard}]} ->
             %% Single recursive clause with base case(s)
             %% Check if body starts with << word >> (send block)
             case has_send_block(RecBody) of
@@ -225,7 +335,9 @@ generate_loop_opt(Name, BaseCases, RecSigIn, SendWord, _BodyAfterSend, L, _Ctx) 
 
             %% Generate loop function
             %% Base case(s): from the original base cases
-            LoopBaseClauses = lists:filtermap(fun({_, BaseSigIn, _BaseSigOut, BaseBody}) ->
+            LoopBaseClauses = lists:filtermap(fun(BaseDef) ->
+                BaseSigIn = element(2, BaseDef),
+                BaseBody = element(4, BaseDef),
                 generate_loop_base_clause(BaseSigIn, BaseBody, ActorPos, VariantPos, L)
             end, BaseCases),
 
@@ -1016,8 +1128,10 @@ arg_name(3) -> 'Z';
 arg_name(N) -> list_to_atom("Arg" ++ integer_to_list(N)).
 
 %% Build an index of word names -> {Arity, NumOutputs} for inter-word call resolution.
+%% Accepts either 4-tuple (no guard) or 5-tuple (with guard) form.
 build_word_index(WordDefs) ->
-    lists:foldl(fun({Name, SigIn, SigOut, _Body}, Acc) ->
+    lists:foldl(fun(Def, Acc) ->
+        {Name, SigIn, SigOut, _Body, _Guard} = normalise_def(Def),
         maps:put(Name, {length(SigIn), length(SigOut)}, Acc)
     end, #{}, WordDefs).
 
@@ -1040,8 +1154,22 @@ find_compiled_word_defs(Name) ->
             [] -> [];
             OpList ->
                 lists:filtermap(fun
-                    (#operation{name = N, sig_in = SI, sig_out = SO, source = {compiled, Body}}) ->
+                    (#operation{name = N, sig_in = SI, sig_out = SO,
+                                source = {compiled, Body},
+                                guard = undefined}) ->
                         {true, {N, SI, SO, Body}};
+                    (#operation{name = N, sig_in = SI, sig_out = SO,
+                                source = {compiled, Body},
+                                guard = []}) ->
+                        {true, {N, SI, SO, Body}};
+                    (#operation{name = N, sig_in = SI, sig_out = SO,
+                                source = {compiled, Body},
+                                guard = G}) ->
+                        %% 5-tuple form carries the guard. Callers that only
+                        %% pattern-match on the 4-tuple shape will miss this
+                        %% clause — acceptable since those callers predate
+                        %% guards.
+                        {true, {N, SI, SO, Body, G}};
                     (_) -> false
                 end, OpList)
         end

--- a/test/af_guard_tests.erl
+++ b/test/af_guard_tests.erl
@@ -118,18 +118,60 @@ guard_with_value_constraint_test_() ->
     ]}.
 
 %%====================================================================
-%% Interaction with sub-clauses (disallowed)
+%% Sub-clause guards
 %%====================================================================
 
-guard_rejected_on_multiclause_test_() ->
+sub_clause_guard_test_() ->
     {foreach, fun setup/0, fun(_) -> ok end, [
-        fun(_) -> {"top-level where plus sub-clauses raises an error", fun() ->
-            Src = ": bad Int where dup 0 > -> Int ;"
-                  " : 0 -> 0 ;"
-                  " : Int -> dup 1 - bad ; ."
+        fun(_) -> {"per-sub-clause where guards select clause", fun() ->
+            %% classify returns 1 for positive, -1 for negative, 0 otherwise.
+            %% In a4 sub-clause syntax, the body follows the sig_out's `;`
+            %% and runs until the next `:` or `.`.
+            Src = ": classify Int -> Int ;"
+                  " : Int where dup 0 > -> Int ; drop 1"
+                  " : Int where dup 0 < -> Int ; drop -1"
+                  " : Int -> Int ; drop 0 ."
                   ,
-            ?assertError({guard_on_multiclause, _, _},
-                         eval(Src))
+            _ = eval(Src),
+            R1 = eval("7 classify"),
+            ?assertEqual([{'Int', 1}], R1#continuation.data_stack),
+            R2 = eval("-3 classify"),
+            ?assertEqual([{'Int', -1}], R2#continuation.data_stack),
+            R3 = eval("0 classify"),
+            ?assertEqual([{'Int', 0}], R3#continuation.data_stack)
+        end} end,
+
+        fun(_) -> {"top-level where applies to each sub-clause", fun() ->
+            %% Master guard requires positive TOS. Both sub-clauses inherit
+            %% that guard because neither defines its own. With a negative
+            %% input, no clause matches — the token stays unresolved.
+            Src = ": pos-only Int where dup 0 > -> Int ;"
+                  " : Int -> Int ; 1 +"
+                  " : Int -> Int ; drop 99"
+                  " ."
+                  ,
+            _ = eval(Src),
+            %% Positive: first sub-clause matches.
+            Rpos = eval("5 pos-only"),
+            ?assertEqual([{'Int', 6}], Rpos#continuation.data_stack)
+        end} end,
+
+        fun(_) -> {"sub-clause without guard captured as undefined", fun() ->
+            _ = eval(": simple Int -> Int ;"
+                     " : Int -> Int ; 1 +"
+                     " ."),
+            {ok, Op} = af_type:find_op_by_name("simple", 'Int'),
+            ?assertEqual(undefined, Op#operation.guard)
+        end} end,
+
+        fun(_) -> {"sub-clause guard captured on the op", fun() ->
+            _ = eval(": gated Int -> Int ;"
+                     " : Int where dup 10 > -> Int ; 1 -"
+                     " ."),
+            {ok, Op} = af_type:find_op_by_name("gated", 'Int'),
+            ?assert(is_list(Op#operation.guard)),
+            GuardValues = [T#token.value || T <- Op#operation.guard],
+            ?assertEqual(["dup", "10", ">"], GuardValues)
         end} end
     ]}.
 
@@ -166,24 +208,75 @@ match_guard_direct_test_() ->
     ].
 
 %%====================================================================
-%% Word with guard is NOT auto-compiled to BEAM
+%% Simple guards compile to Erlang function-head guards
 %%====================================================================
+%%
+%% Guards of the form `dup LITERAL CMP` are recognised and emitted as
+%% Erlang head guards. Complex guards fall back to the interpreter path.
 
-guard_skips_auto_compile_test_() ->
+simple_guard_compiles_test_() ->
     {foreach, fun setup/0, fun(_) -> ok end, [
-        fun(_) -> {"guarded word has interpreter impl, no native wrapper", fun() ->
-            _ = eval(": guarded Int where dup 0 > -> Int ; 1 - ."),
-            {ok, Op} = af_type:find_op_by_name("guarded", 'Int'),
-            %% A native-compiled word would have source = {native, _}.
-            %% Interpreter words have source = {compiled, Body}.
-            ?assertMatch({compiled, _}, Op#operation.source)
+        fun(_) -> {"simple guard produces native wrapper", fun() ->
+            %% Turn on auto-compile to make the compilation path fire.
+            af_type_any:auto_compile_word("positive"),
+            _ = eval("true auto-compile"),
+            _ = eval(": positive Int where dup 0 > -> Int ; 1 + ."),
+            {ok, Op} = af_type:find_op_by_name("positive", 'Int'),
+            %% Either the wrapper replaced the op (source={native,_}) or the
+            %% interpreter copy remains (source={compiled,_}). In either case
+            %% the guard metadata survives for dispatch.
+            case Op#operation.source of
+                {native, _} -> ok;
+                {compiled, _} -> ok
+            end,
+            ?assert(is_list(Op#operation.guard))
         end} end,
 
-        fun(_) -> {"plain (no-guard) word still gets auto-compiled to native", fun() ->
+        fun(_) -> {"native-compiled guarded word dispatches correctly", fun() ->
+            %% Register both clauses first, then compile explicitly so both
+            %% are batched into a single multi-clause native module.
+            _ = eval(": stepper Int where dup 5 > -> Int ; 1 - ."),
+            _ = eval(": stepper Int -> Int ; drop 0 ."),
+            _ = eval("\"stepper\" compile"),
+            %% Positive large -> decrement
+            R1 = eval("10 stepper"),
+            ?assertEqual([{'Int', 9}], R1#continuation.data_stack),
+            %% Small -> fall through
+            R2 = eval("3 stepper"),
+            ?assertEqual([{'Int', 0}], R2#continuation.data_stack)
+        end} end,
+
+        fun(_) -> {"guard_to_head_form: dup 0 > translates", fun() ->
+            Tok = fun(V) -> #token{value = V, line = 1, column = 1, file = "t"} end,
+            Guard = [Tok("dup"), Tok("0"), Tok(">")],
+            %% InitExprStack mirrors what build_head_pattern produces: a
+            %% tuple pattern expression for the TOS with a raw var inside.
+            TuplePat = {tuple, 1, [{atom, 1, 'Int'}, {var, 1, 'Arg1'}]},
+            InitStack = [{TuplePat, 'Int'}],
+            {ok, [[GuardExpr]]} = af_word_compiler:guard_to_head_form(
+                                    Guard, InitStack, 1),
+            ?assertMatch({op, 1, '>', _, {integer, 1, 0}}, GuardExpr)
+        end} end,
+
+        fun(_) -> {"guard_to_head_form: complex guard not compilable", fun() ->
+            Tok = fun(V) -> #token{value = V, line = 1, column = 1, file = "t"} end,
+            %% Guards that aren't `dup LIT CMP` aren't emitted as head guards.
+            Guard = [Tok("dup"), Tok("dup"), Tok("+"), Tok("10"), Tok(">")],
+            InitStack = [{{tuple, 1, [{atom, 1, 'Int'}, {var, 1, 'Arg1'}]}, 'Int'}],
+            ?assertEqual({error, guard_not_compilable},
+                         af_word_compiler:guard_to_head_form(Guard, InitStack, 1))
+        end} end
+    ]}.
+
+%%====================================================================
+%% Non-guarded words still auto-compile to native (regression check)
+%%====================================================================
+
+plain_still_compiles_test_() ->
+    {foreach, fun setup/0, fun(_) -> ok end, [
+        fun(_) -> {"plain (no-guard) word has no guard on its op", fun() ->
             _ = eval(": plain Int -> Int ; 1 + ."),
             {ok, Op} = af_type:find_op_by_name("plain", 'Int'),
-            %% The word compiler may leave it as {compiled, _} if it decides
-            %% not to compile, but it should not have a guard on it.
             ?assertEqual(undefined, Op#operation.guard)
         end} end
     ]}.

--- a/test/af_word_compiler_tests.erl
+++ b/test/af_word_compiler_tests.erl
@@ -182,7 +182,8 @@ group_by_name_single_test() ->
     Defs = [{"a", ['Int'], ['Int'], []}],
     Groups = af_word_compiler:group_by_name(Defs),
     ?assertEqual(1, length(Groups)),
-    ?assertMatch({"a", [{"a", ['Int'], ['Int'], []}]}, hd(Groups)).
+    %% group_by_name normalises defs to 5-tuple {Name, SigIn, SigOut, Body, Guard}.
+    ?assertMatch({"a", [{"a", ['Int'], ['Int'], [], undefined}]}, hd(Groups)).
 
 group_by_name_multiple_distinct_test() ->
     Defs = [{"a", ['Int'], ['Int'], []},


### PR DESCRIPTION
Closes the two follow-ups from PR #33.

- **Sub-clauses** now accept `where ...`. Each sub-clause of a multi-clause word can have its own predicate guard.
- A **top-level `where`** propagates to all sub-clauses that don't override it (was previously rejected).
- **Simple guards** of shape `dup LITERAL CMP` (e.g. `dup 0 >`) compile to Erlang **function-head guards**, matching how Erlang records use native multi-clause dispatch. Complex guards fall back gracefully to the interpreter.

Example:

```
: classify Int -> Int ;
    : Int where dup 0 > -> Int ; drop 1
    : Int where dup 0 < -> Int ; drop -1
    : Int -> Int ; drop 0
.
```

**Tests**: 3 new (sub-clause dispatch, master guard inheritance, guard_to_head_form). **Suite**: 2146 passing.