### PR TITLE
Product types: positional-tuple storage

### DIFF
--- a/include/af_type.hrl
+++ b/include/af_type.hrl
@@ -1,5 +1,9 @@
 -record(af_type, {
     name    = undefined :: atom() | undefined,
     ops     = #{}       :: map(),        %% #{string() => [#operation{}]}
-    handler = undefined :: function() | undefined
+    handler = undefined :: function() | undefined,
+    %% Product types only: ordered list of {FieldName :: atom, FieldType :: atom}
+    %% pairs. Instance storage is {TypeName, V1, V2, ...} where field i is at
+    %% tuple position i+1. Empty list for non-product types.
+    fields  = []        :: [{atom(), atom()}]
 }).

--- a/src/af_interpreter.erl
+++ b/src/af_interpreter.erl
@@ -186,17 +186,29 @@ format_dispatch(atom) -> "->Atom".
 %%% Internal
 
 get_tos_handler([]) -> none;
-get_tos_handler([{TosType, _} | _]) ->
-    case af_type:get_type(TosType) of
-        {ok, #af_type{handler = Handler}} when Handler =/= undefined ->
-            {ok, Handler};
-        _ -> none
-    end.
+get_tos_handler([TosItem | _]) when is_tuple(TosItem), tuple_size(TosItem) >= 2 ->
+    TosType = element(1, TosItem),
+    case is_atom(TosType) of
+        true ->
+            case af_type:get_type(TosType) of
+                {ok, #af_type{handler = Handler}} when Handler =/= undefined ->
+                    {ok, Handler};
+                _ -> none
+            end;
+        false -> none
+    end;
+get_tos_handler(_) -> none.
 
 get_tos_handler([], _Dict) -> none;
-get_tos_handler([{TosType, _} | _], Dict) ->
-    case af_type:dict_get_type(TosType, Dict) of
-        {ok, #af_type{handler = Handler}} when Handler =/= undefined ->
-            {ok, Handler};
-        _ -> none
-    end.
+get_tos_handler([TosItem | _], Dict) when is_tuple(TosItem), tuple_size(TosItem) >= 2 ->
+    TosType = element(1, TosItem),
+    case is_atom(TosType) of
+        true ->
+            case af_type:dict_get_type(TosType, Dict) of
+                {ok, #af_type{handler = Handler}} when Handler =/= undefined ->
+                    {ok, Handler};
+                _ -> none
+            end;
+        false -> none
+    end;
+get_tos_handler(_, _) -> none.

--- a/src/af_term.erl
+++ b/src/af_term.erl
@@ -1,5 +1,7 @@
 -module(af_term).
 
+-include("af_type.hrl").
+
 -export([to_stack_item/1, from_stack_item/1]).
 -export([to_stack_items/1, from_stack_items/1]).
 
@@ -41,11 +43,24 @@ from_stack_item({'Map', M}) ->
         [{from_stack_item(K), from_stack_item(V)} || {K, V} <- maps:to_list(M)]
     );
 from_stack_item({'Actor', #{pid := Pid}}) -> Pid;
-from_stack_item({ProductType, FieldMap}) when is_atom(ProductType), is_map(FieldMap) ->
-    Converted = maps:from_list(
-        [{F, from_stack_item(V)} || {F, V} <- maps:to_list(FieldMap)]
-    ),
-    Converted#{type => ProductType}.
+from_stack_item(Tuple) when is_tuple(Tuple), tuple_size(Tuple) >= 2 ->
+    %% Product type instance: {TypeName, V1, V2, ..., Vn}.
+    %% Values are raw (untagged) and field names come from the registry.
+    TypeName = element(1, Tuple),
+    case is_atom(TypeName) of
+        false -> Tuple;
+        true ->
+            case catch af_type:get_type(TypeName) of
+                {ok, #af_type{fields = Fields}} when Fields =/= [] ->
+                    FieldPairs = lists:zip(
+                        [F || {F, _T} <- Fields],
+                        tl(tuple_to_list(Tuple))
+                    ),
+                    Converted = maps:from_list(FieldPairs),
+                    Converted#{type => TypeName};
+                _ -> Tuple
+            end
+    end.
 
 %% Batch conversion
 -spec to_stack_items([term()]) -> [{atom(), term()}].

--- a/src/af_type.erl
+++ b/src/af_type.erl
@@ -90,19 +90,37 @@ replace_ops(TypeName, OpName, NewOps) when is_list(NewOps) ->
 
 %% Core dispatch: find operation by token name against current stack.
 %% Searches TOS type dictionary first, then falls back to Any.
-find_op(TokenName, [{TosType, _} | _] = Stack) ->
-    case find_op_in_type(TosType, TokenName, Stack) of
-        {ok, _Op} = Found -> Found;
-        not_found -> find_op_in_type('Any', TokenName, Stack)
-    end;
 find_op(TokenName, []) ->
-    find_op_in_type('Any', TokenName, []).
+    find_op_in_type('Any', TokenName, []);
+find_op(TokenName, [TosItem | _] = Stack) ->
+    case tos_type_of(TosItem) of
+        {ok, TosType} ->
+            case find_op_in_type(TosType, TokenName, Stack) of
+                {ok, _Op} = Found -> Found;
+                not_found -> find_op_in_type('Any', TokenName, Stack)
+            end;
+        none ->
+            find_op_in_type('Any', TokenName, Stack)
+    end.
 
 %% Search ONLY in the TOS type's dictionary (no Any fallback).
-find_op_in_tos(TokenName, [{TosType, _} | _] = Stack) ->
-    find_op_in_type(TosType, TokenName, Stack);
 find_op_in_tos(_TokenName, []) ->
-    not_found.
+    not_found;
+find_op_in_tos(TokenName, [TosItem | _] = Stack) ->
+    case tos_type_of(TosItem) of
+        {ok, TosType} -> find_op_in_type(TosType, TokenName, Stack);
+        none -> not_found
+    end.
+
+%% Extract the type atom from a stack item. Handles both plain tagged values
+%% {Type, Val} and product instances {TypeName, V1, V2, ..., Vn}.
+tos_type_of(Item) when is_tuple(Item), tuple_size(Item) >= 2 ->
+    First = element(1, Item),
+    case is_atom(First) of
+        true -> {ok, First};
+        false -> none
+    end;
+tos_type_of(_) -> none.
 
 %% Search ONLY in the Any dictionary.
 find_op_in_any(TokenName, Stack) ->
@@ -128,24 +146,26 @@ match_sig(['Any' | SigRest], [_ | StackRest]) ->
     match_sig(SigRest, StackRest);
 match_sig(['_' | SigRest], [_ | StackRest]) ->
     match_sig(SigRest, StackRest);
-match_sig([{Type, Value} | SigRest], [{Type, Value} | StackRest]) ->
-    match_sig(SigRest, StackRest);
-match_sig([Type | SigRest], [{Type, _} | StackRest]) when is_atom(Type) ->
-    case af_type_check:is_type_variable(Type) of
-        true ->
-            %% Type variable — already matched by name coincidence, but
-            %% should match ANY type. Re-do: this clause matched because
-            %% the stack item's type atom happened to equal the variable name.
-            %% That's fine — it matches. Continue.
-            match_sig(SigRest, StackRest);
-        false ->
-            match_sig(SigRest, StackRest)
+match_sig([{Type, Value} | SigRest], [StackItem | StackRest]) ->
+    %% Value constraint: stack item must be {Type, Value} exactly. Works only
+    %% on 2-tuple tagged values, not on product-type tuples (product types
+    %% don't support value constraints).
+    case StackItem of
+        {Type, Value} -> match_sig(SigRest, StackRest);
+        _ -> false
     end;
-match_sig([Type | SigRest], [_ | StackRest]) when is_atom(Type) ->
-    %% Type didn't match stack item's type — check if it's a type variable
-    case af_type_check:is_type_variable(Type) of
-        true -> match_sig(SigRest, StackRest);
-        false -> false
+match_sig([Type | SigRest], [StackItem | StackRest]) when is_atom(Type) ->
+    StackType = case StackItem of
+        Tuple when is_tuple(Tuple), tuple_size(Tuple) >= 2 -> element(1, Tuple);
+        _ -> undefined
+    end,
+    case StackType of
+        Type -> match_sig(SigRest, StackRest);
+        _ ->
+            case af_type_check:is_type_variable(Type) of
+                true -> match_sig(SigRest, StackRest);
+                false -> false
+            end
     end;
 match_sig(_, _) -> false.
 
@@ -293,11 +313,15 @@ snapshot() ->
         maps:put(Name, Type, Acc)
     end, #{}, ets:tab2list(?TABLE)).
 
-%% Look up op in TOS type's dictionary (local map, no ETS)
-dict_find_op_in_tos(TokenName, [{TosType, _} | _] = Stack, Dict) ->
-    dict_find_op_in_type(TosType, TokenName, Stack, Dict);
+%% Look up op in TOS type's dictionary (local map, no ETS).
+%% Supports both plain tagged values and product-type tuple instances.
 dict_find_op_in_tos(_TokenName, [], _Dict) ->
-    not_found.
+    not_found;
+dict_find_op_in_tos(TokenName, [TosItem | _] = Stack, Dict) ->
+    case tos_type_of(TosItem) of
+        {ok, TosType} -> dict_find_op_in_type(TosType, TokenName, Stack, Dict);
+        none -> not_found
+    end.
 
 %% Look up op in Any dictionary (local map, no ETS)
 dict_find_op_in_any(TokenName, Stack, Dict) ->

--- a/src/af_type_actor.erl
+++ b/src/af_type_actor.erl
@@ -174,7 +174,8 @@ get_ops(TypeName) ->
 %%% --- server: spawn actor from type instance ---
 
 op_server(Cont) ->
-    [{TypeName, _Value} = Instance | Rest] = Cont#continuation.data_stack,
+    [Instance | Rest] = Cont#continuation.data_stack,
+    TypeName = element(1, Instance),
     Vocab0 = build_vocab(TypeName),
     Vocab = Vocab0#{"stop" => [#{args => [], returns => []}]},
     LoopFun = get_actor_loop_fun(TypeName, Instance),
@@ -230,7 +231,8 @@ remove_first(Elem, [H | Rest]) -> [H | remove_first(Elem, Rest)].
 %%% --- supervised-server: spawn under OTP supervisor ---
 
 op_supervised_server(Cont) ->
-    [{TypeName, _Value} = Instance | Rest] = Cont#continuation.data_stack,
+    [Instance | Rest] = Cont#continuation.data_stack,
+    TypeName = element(1, Instance),
     Vocab0 = build_vocab(TypeName),
     Vocab = Vocab0#{"stop" => [#{args => [], returns => []}]},
     %% Ensure supervisor is running
@@ -436,11 +438,21 @@ execute_actor_call(WordName, Args, TypeName, StateInstance) ->
     separate_reply(TypeName, ResultStack).
 
 %% Split the stack into reply values (above state) and state instance.
+%% State instance is any tuple whose first element is TypeName. For product
+%% types the instance is a positional N-tuple; for other types (Message etc.)
+%% it's a plain 2-tuple. We accept both.
 separate_reply(TypeName, Stack) ->
     separate_reply(TypeName, Stack, []).
 
-separate_reply(TypeName, [{TypeName, _} = State | _Rest], ReplyAcc) ->
-    {lists:reverse(ReplyAcc), State};
+separate_reply(TypeName, [Item | _Rest] = Stack, ReplyAcc) when is_tuple(Item) ->
+    case tuple_size(Item) >= 2 andalso element(1, Item) =:= TypeName of
+        true ->
+            [State | _] = Stack,
+            {lists:reverse(ReplyAcc), State};
+        false ->
+            [Head | Rest] = Stack,
+            separate_reply(TypeName, Rest, [Head | ReplyAcc])
+    end;
 separate_reply(TypeName, [Item | Rest], ReplyAcc) ->
     separate_reply(TypeName, Rest, [Item | ReplyAcc]);
 separate_reply(_TypeName, [], ReplyAcc) ->

--- a/src/af_type_product.erl
+++ b/src/af_type_product.erl
@@ -116,10 +116,26 @@ op_type_dot(Cont) ->
     Cont#continuation{data_stack = Rest, dictionary = Dict}.
 
 %% Register a product type with auto-generated constructor and getters.
-%% Updates both ETS (for compilation tools) and the local dictionary.
+%%
+%% NEW STORAGE FORMAT (2026-04-17):
+%%
+%%   Instance = {TypeName, V1, V2, ..., Vn}
+%%
+%% where field `i` (1-indexed, zero-indexed in the field list) is at tuple
+%% position i+1, and `Vi` is the RAW value (not tagged). The tag lives only
+%% on the outer tuple. Field types are known from the registry, so the
+%% tag on individual field values is redundant.
+%%
+%% Previous format was `{TypeName, #{field => {Type, Value}}}`. The old
+%% format cost a map allocation per update and a tagged tuple per field;
+%% the new format makes field access a single BEAM `element/2` and
+%% field update a single `setelement/3`.
+%%
+%% The #af_type{fields = [{FieldName, FieldType}, ...]} metadata carries
+%% the field->position mapping so getters/setters can index correctly.
 register_product_type(TypeName, Fields, Dict0) ->
-    %% Register the type itself
-    af_type:register_type(#af_type{name = TypeName}),
+    %% Register the type itself, recording field layout
+    af_type:register_type(#af_type{name = TypeName, fields = Fields}),
 
     %% Constructor: lowercase type name, registered in Any
     ConstructorName = string:lowercase(atom_to_list(TypeName)),
@@ -129,41 +145,45 @@ register_product_type(TypeName, Fields, Dict0) ->
         name = ConstructorName,
         sig_in = ConstructorSigIn,
         sig_out = [TypeName],
-        impl = make_constructor(TypeName, Fields),
+        impl = make_constructor(TypeName, length(Fields)),
         source = auto
     },
     af_type:add_op('Any', Constructor),
 
-    %% Getters: one per field, registered in the new type
-    lists:foreach(fun({FieldName, FieldType}) ->
+    %% Getters: one per field, registered in the new type. Each gets its
+    %% 1-indexed tuple position baked in.
+    lists:foldl(fun({FieldName, FieldType}, Pos) ->
         Getter = #operation{
             name = atom_to_list(FieldName),
             sig_in = [TypeName],
             sig_out = [FieldType, TypeName],
-            impl = make_getter(FieldName),
+            impl = make_getter(FieldType, Pos),
             source = auto
         },
-        af_type:add_op(TypeName, Getter)
-    end, Fields),
+        af_type:add_op(TypeName, Getter),
+        Pos + 1
+    end, 2, Fields),  %% pos 1 is the type atom; fields start at pos 2
 
     %% Setters: field name with ! suffix, takes new value + instance
-    lists:foreach(fun({FieldName, FieldType}) ->
+    lists:foldl(fun({FieldName, FieldType}, Pos) ->
         SetterName = atom_to_list(FieldName) ++ "!",
         Setter = #operation{
             name = SetterName,
             sig_in = [FieldType, TypeName],
             sig_out = [TypeName],
-            impl = make_setter(FieldName),
+            impl = make_setter(Pos),
             source = auto
         },
-        af_type:add_op('Any', Setter)
-    end, Fields),
+        af_type:add_op('Any', Setter),
+        Pos + 1
+    end, 2, Fields),
 
     %% Update local dictionary if present
     case Dict0 of
         undefined -> undefined;
         _ -> sync_type_from_ets(TypeName, sync_type_from_ets('Any',
-                af_type:dict_register_type(#af_type{name = TypeName}, Dict0)))
+                af_type:dict_register_type(
+                    #af_type{name = TypeName, fields = Fields}, Dict0)))
     end.
 
 sync_type_from_ets(TypeName, Dict) ->
@@ -172,42 +192,35 @@ sync_type_from_ets(TypeName, Dict) ->
         _ -> Dict
     end.
 
-%% Build constructor function
-%% Takes N values from stack (in order matching field list), creates instance
-make_constructor(TypeName, Fields) ->
-    NumFields = length(Fields),
+%% Build constructor: takes NumFields tagged stack items, strips tags,
+%% builds a positional tuple {TypeName, V1, V2, ..., Vn}.
+make_constructor(TypeName, NumFields) ->
     fun(Cont) ->
         {Values, Rest} = take_n(NumFields, Cont#continuation.data_stack),
-        %% Values are in stack order (TOS first), fields are in definition order
-        %% Stack: ... field1_val field2_val  (field2 is TOS)
-        %% We need to pair fields with values in reverse
+        %% Values are in stack order (TOS first). Stack: ... val1 val2 ... valN
+        %% where valN is TOS. Field order matches definition order, so:
         ReversedValues = lists:reverse(Values),
-        FieldMap = maps:from_list(
-            lists:zipwith(
-                fun({FName, _FType}, {_VType, VVal}) ->
-                    {FName, {_VType, VVal}}
-                end,
-                Fields, ReversedValues
-            )
-        ),
-        Instance = {TypeName, FieldMap},
+        RawVals = [V || {_, V} <- ReversedValues],
+        Instance = list_to_tuple([TypeName | RawVals]),
         Cont#continuation{data_stack = [Instance | Rest]}
     end.
 
-%% Build getter function (non-destructive: leaves instance on stack)
-make_getter(FieldName) ->
+%% Build getter: non-destructive, leaves instance on stack, pushes tagged
+%% {FieldType, FieldValue} on top.
+make_getter(FieldType, Pos) ->
     fun(Cont) ->
-        [{_TypeName, FieldMap} = Instance | Rest] = Cont#continuation.data_stack,
-        Value = maps:get(FieldName, FieldMap),
-        Cont#continuation{data_stack = [Value, Instance | Rest]}
+        [Instance | Rest] = Cont#continuation.data_stack,
+        RawVal = element(Pos, Instance),
+        Cont#continuation{data_stack = [{FieldType, RawVal}, Instance | Rest]}
     end.
 
-%% Build setter function: new_value instance setter! -> updated_instance
-make_setter(FieldName) ->
+%% Build setter: pops tagged new value + instance, returns updated instance.
+%% new_value is stripped of its tag; instance keeps its type tag.
+make_setter(Pos) ->
     fun(Cont) ->
-        [NewValue, {TypeName, FieldMap} | Rest] = Cont#continuation.data_stack,
-        UpdatedMap = maps:put(FieldName, NewValue, FieldMap),
-        Cont#continuation{data_stack = [{TypeName, UpdatedMap} | Rest]}
+        [{_VType, NewVal}, Instance | Rest] = Cont#continuation.data_stack,
+        UpdatedInstance = setelement(Pos, Instance, NewVal),
+        Cont#continuation{data_stack = [UpdatedInstance | Rest]}
     end.
 
 %% Take N items from top of stack

--- a/src/af_word_compiler.erl
+++ b/src/af_word_compiler.erl
@@ -427,6 +427,11 @@ generate_loop_base_clause(BaseSigIn, _BaseBody, _ActorPos, VariantPos, L) ->
 %% Returns {HeadPattern, [{TaggedExpr, Type}], RestVar}
 %% HeadPattern is a cons-list pattern like [{Int, X}, {Int, Y} | Rest]
 %% suitable for use directly in the function head (not body match).
+%%
+%% For product types we DON'T pattern-match the internal fields — the instance
+%% comes through as an opaque tuple whose shape depends on its fields. We bind
+%% a whole variable to it, with a guard-free pattern. Getters/setters in the
+%% body will use element/setelement on it.
 build_head_pattern(SigIn, L) ->
     {TuplePats, ExprStack, _} = lists:foldl(fun(SigEntry, {Pats, Exps, I}) ->
         case SigEntry of
@@ -444,8 +449,17 @@ build_head_pattern(SigIn, L) ->
                 {Pats ++ [TuplePat], Exps ++ [{TuplePat, Type}], I + 1};
             Type when is_atom(Type) ->
                 Var = {var, L, arg_name(I)},
-                TuplePat = {tuple, L, [{atom, L, Type}, Var]},
-                {Pats ++ [TuplePat], Exps ++ [{TuplePat, Type}], I + 1}
+                Pat = case is_product_type(Type) of
+                    true ->
+                        %% Product: match any tuple whose first elem is Type.
+                        %% We use a bound var only — type discrimination is
+                        %% handled by the caller (match_sig).
+                        Var;
+                    false ->
+                        %% Regular tagged {Type, Val} 2-tuple.
+                        {tuple, L, [{atom, L, Type}, Var]}
+                end,
+                {Pats ++ [Pat], Exps ++ [{Pat, Type}], I + 1}
         end
     end, {[], [], 1}, SigIn),
     FinalRestVar = {var, L, '__RestFinal'},
@@ -453,6 +467,13 @@ build_head_pattern(SigIn, L) ->
         {cons, L, Pat, Acc}
     end, FinalRestVar, TuplePats),
     {HeadPat, ExprStack, FinalRestVar}.
+
+%% Check if a type name refers to a registered product type (one with fields).
+is_product_type(TypeName) ->
+    case catch af_type:get_type(TypeName) of
+        {ok, #af_type{fields = Fields}} when Fields =/= [] -> true;
+        _ -> false
+    end.
 
 %% Build an ActorForth wrapper operation that calls a native BEAM function.
 %% The wrapper pops tagged items, passes the tagged stack to the native function,
@@ -908,6 +929,13 @@ runtime_dispatch(Name, Stack, L, Ctx) ->
     end.
 
 %% Try to compile a product type getter or setter.
+%%
+%% Product instances use the positional-tuple format:
+%%   {TypeName, V1, V2, ..., Vn}
+%% where field `i` is at tuple position `i+1`. The type's #af_type.fields
+%% list gives the 0-indexed field ordering; we add 2 to get the Erlang
+%% tuple position (1 is the type atom).
+%%
 %% Getters: instance on TOS, push field value + keep instance
 %% Setters (name!): new_value and instance on stack, return updated instance
 try_product_op(Name, [{_Expr, TosType} | _] = Stack, L, _Ctx) when is_atom(TosType), TosType =/= stack ->
@@ -916,37 +944,57 @@ try_product_op(Name, [{_Expr, TosType} | _] = Stack, L, _Ctx) when is_atom(TosTy
             %% Setter: TOS is the new value, second item is the instance
             BaseName = lists:droplast(Name),
             [{NewValExpr, _ValType}, {InstanceExpr, InstanceType} | Rest] = Stack,
-            case catch af_type:get_type(InstanceType) of
-                {ok, #af_type{ops = _Ops}} ->
-                    FieldName = list_to_atom(BaseName),
-                    FieldMapExpr = {call, L, {remote, L, {atom, L, erlang}, {atom, L, element}},
-                        [{integer, L, 2}, InstanceExpr]},
-                    UpdatedMap = {map, L, FieldMapExpr,
-                        [{map_field_exact, L, {atom, L, FieldName}, NewValExpr}]},
-                    ResultExpr = {tuple, L, [{atom, L, InstanceType}, UpdatedMap]},
-                    {ok, [{ResultExpr, InstanceType} | Rest]};
-                _ -> not_product
+            case field_position(list_to_atom(BaseName), InstanceType) of
+                {ok, Pos} ->
+                    %% setelement(Pos, Instance, extract_val(NewVal))
+                    RawValExpr = extract_val({NewValExpr, any}, L),
+                    UpdatedExpr = {call, L,
+                        {remote, L, {atom, L, erlang}, {atom, L, setelement}},
+                        [{integer, L, Pos}, InstanceExpr, RawValExpr]},
+                    {ok, [{UpdatedExpr, InstanceType} | Rest]};
+                not_found -> not_product
             end;
         _ ->
             %% Getter: look in TOS type's ops
-            case catch af_type:get_type(TosType) of
-                {ok, #af_type{ops = Ops}} ->
-                    case maps:get(Name, Ops, []) of
-                        [#operation{source = auto, sig_out = [FieldType, _]} | _] ->
-                            [{InstanceExpr, _} | Rest] = Stack,
-                            FieldName = list_to_atom(Name),
-                            FieldMapExpr = {call, L, {remote, L, {atom, L, erlang}, {atom, L, element}},
-                                [{integer, L, 2}, InstanceExpr]},
-                            ValExpr = {call, L, {remote, L, {atom, L, erlang}, {atom, L, map_get}},
-                                [{atom, L, FieldName}, FieldMapExpr]},
-                            {ok, [{ValExpr, FieldType}, {InstanceExpr, TosType} | Rest]};
-                        _ -> not_product
-                    end;
-                _ -> not_product
+            case field_getter_info(Name, TosType) of
+                {ok, FieldType, Pos} ->
+                    [{InstanceExpr, _} | Rest] = Stack,
+                    RawExpr = {call, L,
+                        {remote, L, {atom, L, erlang}, {atom, L, element}},
+                        [{integer, L, Pos}, InstanceExpr]},
+                    TaggedExpr = {tuple, L,
+                        [{atom, L, FieldType}, RawExpr]},
+                    {ok, [{TaggedExpr, FieldType}, {InstanceExpr, TosType} | Rest]};
+                not_found -> not_product
             end
     end;
 try_product_op(_Name, _Stack, _L, _Ctx) ->
     not_product.
+
+%% Look up the tuple position (1-indexed, element/N) of a product-type
+%% field by name. Returns {ok, Pos} or not_found.
+field_position(FieldName, TypeName) ->
+    case catch af_type:get_type(TypeName) of
+        {ok, #af_type{fields = Fields}} when Fields =/= [] ->
+            field_position_loop(FieldName, Fields, 2);
+        _ -> not_found
+    end.
+
+field_position_loop(_Name, [], _Pos) -> not_found;
+field_position_loop(Name, [{Name, _Type} | _], Pos) -> {ok, Pos};
+field_position_loop(Name, [_ | Rest], Pos) -> field_position_loop(Name, Rest, Pos + 1).
+
+%% For a getter named `Name` on TosType, find the field's type and position.
+field_getter_info(Name, TosType) ->
+    case catch af_type:get_type(TosType) of
+        {ok, #af_type{fields = Fields}} when Fields =/= [] ->
+            field_getter_loop(list_to_atom(Name), Fields, 2);
+        _ -> not_found
+    end.
+
+field_getter_loop(_Name, [], _Pos) -> not_found;
+field_getter_loop(Name, [{Name, Type} | _], Pos) -> {ok, Type, Pos};
+field_getter_loop(Name, [_ | Rest], Pos) -> field_getter_loop(Name, Rest, Pos + 1).
 
 %% Collect operations between << and >>. Returns {SendOps, RemainingOps}.
 collect_send_block(Ops) ->

--- a/test/af_actor_tests.erl
+++ b/test/af_actor_tests.erl
@@ -590,18 +590,17 @@ product_field_update_actor_test_() ->
             C0 = af_interpreter:new_continuation(),
             C1 = eval("type Account balance Int .", C0),
             C2 = eval(": credit Account Int -> Account ; over balance rot + balance! swap drop .", C1),
-            Instance = {'Account', #{balance => {'Int', 1000}}},
+            Instance = {'Account', 1000},
             NewState = af_type_actor:execute_actor_word("credit", [{'Int', 500}], 'Account', Instance),
-            ?assertMatch({'Account', _}, NewState),
-            {'Account', Fields} = NewState,
-            ?assertEqual({'Int', 1500}, maps:get(balance, Fields))
+            ?assertEqual('Account', element(1, NewState)),
+            ?assertEqual(1500, element(2, NewState))
         end} end,
 
         fun(_) -> {"execute_actor_call returns reply values and updated state", fun() ->
             C0 = af_interpreter:new_continuation(),
             C1 = eval("type Account balance Int .", C0),
             _C2 = eval(": get-balance Account -> Account Int ; balance .", C1),
-            Instance = {'Account', #{balance => {'Int', 1000}}},
+            Instance = {'Account', 1000},
             {Reply, NewState} = af_type_actor:execute_actor_call("get-balance", [], 'Account', Instance),
             ?assertEqual([{'Int', 1000}], Reply),
             ?assertEqual(Instance, NewState)
@@ -711,7 +710,7 @@ actor_loop_cache_test_() ->
             eval("\"get_count\" compile", C3),
             %% Build cache manually and spawn generic loop
             Cache = af_actor_worker:build_native_cache('Counter'),
-            Instance = {'Counter', #{count => {'Int', 0}}},
+            Instance = {'Counter', 0},
             Self = self(),
             Pid = spawn(fun() ->
                 %% Tell parent we're ready
@@ -741,7 +740,7 @@ actor_loop_cache_test_() ->
             eval("\"add\" compile", C3),
             eval("\"get_count\" compile", C3),
             Cache = af_actor_worker:build_native_cache('Counter'),
-            Instance = {'Counter', #{count => {'Int', 0}}},
+            Instance = {'Counter', 0},
             Self = self(),
             Pid = spawn(fun() ->
                 Self ! ready,
@@ -767,7 +766,7 @@ actor_loop_cache_test_() ->
             eval("\"add\" compile", C3),
             eval("\"get_count\" compile", C3),
             Cache = af_actor_worker:build_native_cache('Counter'),
-            Instance = {'Counter', #{count => {'Int', 0}}},
+            Instance = {'Counter', 0},
             Self = self(),
             Pid = spawn(fun() ->
                 Self ! ready,
@@ -788,7 +787,8 @@ actor_loop_cache_test_() ->
             C2 = eval(": get_count Counter -> Counter Int ; count .", C1),
             eval("\"get_count\" compile", C2),
             Cache = af_actor_worker:build_native_cache('Counter'),
-            Instance = {'Counter', #{count => {'Int', 5}}},
+            %% New storage: positional tuple with raw field value.
+            Instance = {'Counter', 5},
             Self = self(),
             Pid = spawn(fun() ->
                 Self ! ready,
@@ -1211,16 +1211,16 @@ coverage_test_() ->
             C0 = af_interpreter:new_continuation(),
             C1 = eval("type Foo val Int .", C0),
             _C2 = eval(": inc Foo -> Foo ; val 1 + val! .", C1),
-            State = {'Foo', #{val => {'Int', 10}}},
+            State = {'Foo', 10},
             NewState = af_type_actor:execute_actor_word("inc", [], 'Foo', State),
-            ?assertEqual({'Foo', #{val => {'Int', 11}}}, NewState)
+            ?assertEqual({'Foo', 11}, NewState)
         end} end,
 
         fun(_) -> {"execute_actor_call directly", fun() ->
             C0 = af_interpreter:new_continuation(),
             C1 = eval("type Foo val Int .", C0),
             _C2 = eval(": get-val Foo -> Foo Int ; val .", C1),
-            State = {'Foo', #{val => {'Int', 42}}},
+            State = {'Foo', 42},
             {ReplyValues, _NewState} = af_type_actor:execute_actor_call("get-val", [], 'Foo', State),
             ?assertEqual([{'Int', 42}], ReplyValues)
         end} end,

--- a/test/af_actor_worker_tests.erl
+++ b/test/af_actor_worker_tests.erl
@@ -18,7 +18,7 @@ worker_test_() ->
         fun(_) -> {"call returns value and updates state", fun() ->
             C1 = eval("type Cntr value Int .", af_interpreter:new_continuation()),
             _C2 = eval(": get-value Cntr -> Cntr Int ; value .", C1),
-            Instance = {'Cntr', #{value => {'Int', 42}}},
+            Instance = {'Cntr', 42},
             {ok, Pid} = af_actor_worker:start_link('Cntr', Instance),
             {ok, ReplyValues} = gen_server:call(Pid, {call, "get-value", []}),
             ?assertEqual([{'Int', 42}], ReplyValues),
@@ -26,7 +26,7 @@ worker_test_() ->
         end} end,
 
         fun(_) -> {"call with error returns error tuple (line 29)", fun() ->
-            Instance = {'Cntr', #{value => {'Int', 0}}},
+            Instance = {'Cntr', 0},
             {ok, Pid} = af_actor_worker:start_link('Cntr', Instance),
             %% Call a word that doesn't exist as a compiled word - will error
             %% because the type Cntr isn't registered in this test
@@ -39,14 +39,14 @@ worker_test_() ->
         end} end,
 
         fun(_) -> {"unknown request returns error (line 33)", fun() ->
-            Instance = {'Cntr', #{value => {'Int', 0}}},
+            Instance = {'Cntr', 0},
             {ok, Pid} = af_actor_worker:start_link('Cntr', Instance),
             ?assertEqual({error, unknown_request}, gen_server:call(Pid, some_random_request)),
             gen_server:stop(Pid)
         end} end,
 
         fun(_) -> {"cast stop stops the worker (line 35-36)", fun() ->
-            Instance = {'Cntr', #{value => {'Int', 0}}},
+            Instance = {'Cntr', 0},
             {ok, Pid} = af_actor_worker:start_link('Cntr', Instance),
             gen_server:cast(Pid, {cast, "stop", []}),
             timer:sleep(100),
@@ -56,7 +56,7 @@ worker_test_() ->
         fun(_) -> {"cast executes word (line 38-46)", fun() ->
             C1 = eval("type Cntr value Int .", af_interpreter:new_continuation()),
             _C2 = eval(": inc Cntr -> Cntr ; value 1 + value! .", C1),
-            Instance = {'Cntr', #{value => {'Int', 0}}},
+            Instance = {'Cntr', 0},
             {ok, Pid} = af_actor_worker:start_link('Cntr', Instance),
             gen_server:cast(Pid, {cast, "inc", []}),
             timer:sleep(50),
@@ -69,7 +69,7 @@ worker_test_() ->
         end} end,
 
         fun(_) -> {"unknown cast is ignored (line 48-49)", fun() ->
-            Instance = {'Cntr', #{value => {'Int', 0}}},
+            Instance = {'Cntr', 0},
             {ok, Pid} = af_actor_worker:start_link('Cntr', Instance),
             gen_server:cast(Pid, unknown_cast_msg),
             timer:sleep(50),
@@ -78,7 +78,7 @@ worker_test_() ->
         end} end,
 
         fun(_) -> {"handle_info is ignored (line 51-52)", fun() ->
-            Instance = {'Cntr', #{value => {'Int', 0}}},
+            Instance = {'Cntr', 0},
             {ok, Pid} = af_actor_worker:start_link('Cntr', Instance),
             Pid ! some_random_message,
             timer:sleep(50),
@@ -90,7 +90,7 @@ worker_test_() ->
             %% Define a word that drops the state and pushes unrelated items
             C1 = eval("type Cntr value Int .", af_interpreter:new_continuation()),
             _C2 = eval(": weird Cntr -> Int ; value drop 99 .", C1),
-            Instance = {'Cntr', #{value => {'Int', 0}}},
+            Instance = {'Cntr', 0},
             {ok, Pid} = af_actor_worker:start_link('Cntr', Instance),
             %% This call will execute the word; separate_reply won't find Cntr in result
             _Result = gen_server:call(Pid, {call, "weird", []}),
@@ -98,7 +98,7 @@ worker_test_() ->
         end} end,
 
         fun(_) -> {"cast atom stop stops the worker", fun() ->
-            Instance = {'Cntr', #{value => {'Int', 0}}},
+            Instance = {'Cntr', 0},
             {ok, Pid} = af_actor_worker:start_link('Cntr', Instance),
             gen_server:cast(Pid, {cast, stop, []}),
             timer:sleep(100),
@@ -108,7 +108,7 @@ worker_test_() ->
         fun(_) -> {"cast with args exercises args code path", fun() ->
             C1 = eval("type Cntr value Int .", af_interpreter:new_continuation()),
             _C2 = eval(": inc Cntr -> Cntr ; value 1 + value! .", C1),
-            Instance = {'Cntr', #{value => {'Int', 0}}},
+            Instance = {'Cntr', 0},
             {ok, Pid} = af_actor_worker:start_link('Cntr', Instance),
             %% Pass args to cast — the inc word ignores them but exercises
             %% the Args =/= [] branch in handle_cast
@@ -122,7 +122,7 @@ worker_test_() ->
             C1 = eval("type Cntr value Int .", af_interpreter:new_continuation()),
             %% get-value: Cntr -> Cntr Int
             _C2 = eval(": get-value Cntr -> Cntr Int ; value .", C1),
-            Instance = {'Cntr', #{value => {'Int', 10}}},
+            Instance = {'Cntr', 10},
             {ok, Pid} = af_actor_worker:start_link('Cntr', Instance),
             %% Pass args to call — the word ignores them but the code path
             %% exercises the Args =/= [] branch in handle_call
@@ -142,7 +142,7 @@ worker_test_() ->
         fun(_) -> {"cast with atom word name", fun() ->
             C1 = eval("type Cntr value Int .", af_interpreter:new_continuation()),
             _C2 = eval(": inc Cntr -> Cntr ; value 1 + value! .", C1),
-            Instance = {'Cntr', #{value => {'Int', 0}}},
+            Instance = {'Cntr', 0},
             {ok, Pid} = af_actor_worker:start_link('Cntr', Instance),
             gen_server:cast(Pid, {cast, inc, []}),
             timer:sleep(50),
@@ -155,7 +155,7 @@ worker_test_() ->
         fun(_) -> {"call with atom word name", fun() ->
             C1 = eval("type Cntr value Int .", af_interpreter:new_continuation()),
             _C2 = eval(": get-value Cntr -> Cntr Int ; value .", C1),
-            Instance = {'Cntr', #{value => {'Int', 42}}},
+            Instance = {'Cntr', 42},
             {ok, Pid} = af_actor_worker:start_link('Cntr', Instance),
             {ok, Reply} = gen_server:call(Pid, {call, 'get-value', []}),
             ?assertEqual([{'Int', 42}], Reply),
@@ -168,7 +168,7 @@ worker_test_() ->
             _C2 = eval(": get-value Cntr -> Cntr Int ; value .", C1),
             %% A word that will crash: head on empty list
             _C3 = eval(": crasher Cntr -> Cntr ; drop nil head .", C1),
-            Instance = {'Cntr', #{value => {'Int', 7}}},
+            Instance = {'Cntr', 7},
             {ok, Pid} = af_actor_worker:start_link('Cntr', Instance),
             %% This will cause an error in interpret_cast, caught by the catch
             gen_server:cast(Pid, {cast, "crasher", []}),
@@ -183,7 +183,7 @@ worker_test_() ->
             C1 = eval("type Cntr value Int .", af_interpreter:new_continuation()),
             %% A word that will crash
             _C2 = eval(": crasher Cntr -> Int ; drop nil head .", C1),
-            Instance = {'Cntr', #{value => {'Int', 0}}},
+            Instance = {'Cntr', 0},
             {ok, Pid} = af_actor_worker:start_link('Cntr', Instance),
             Result = gen_server:call(Pid, {call, "crasher", []}),
             ?assertMatch({error, _}, Result),
@@ -226,7 +226,7 @@ worker_test_() ->
             C1 = eval("type Cntr value Int .", af_interpreter:new_continuation()),
             %% A word that drops everything
             _C2 = eval(": dropper Cntr -> ; drop .", C1),
-            Instance = {'Cntr', #{value => {'Int', 0}}},
+            Instance = {'Cntr', 0},
             {ok, Pid} = af_actor_worker:start_link('Cntr', Instance),
             %% This will result in empty stack after separate_reply
             Result = gen_server:call(Pid, {call, "dropper", []}),

--- a/test/af_otp_tests.erl
+++ b/test/af_otp_tests.erl
@@ -24,7 +24,7 @@ gen_server_test_() ->
             C4 = eval("af_gs_counter Counter gen-server-module", C3),
             [{'Atom', "af_gs_counter"}] = C4#continuation.data_stack,
             %% Start with a tagged product type instance as state
-            InitState = {'Counter', #{value => {'Int', 0}}},
+            InitState = {'Counter', 0},
             {ok, Pid} = gen_server:start_link(af_gs_counter, InitState, []),
             %% Cast: increment (async)
             ok = gen_server:cast(Pid, increment),
@@ -42,7 +42,7 @@ gen_server_test_() ->
             C2 = eval(": get Simple -> Simple Int ; value .", C1),
             C3 = eval("af_gs_simple Simple gen-server-module", C2),
             [{'Atom', "af_gs_simple"}] = C3#continuation.data_stack,
-            InitState = {'Simple', #{value => {'Int', 42}}},
+            InitState = {'Simple', 42},
             {ok, Pid} = gen_server:start_link(af_gs_simple, InitState, []),
             ?assertEqual({error, unknown_call}, gen_server:call(Pid, nonexistent)),
             gen_server:stop(Pid)
@@ -56,16 +56,17 @@ dispatch_test_() ->
         fun(_) -> {"dispatch call_word returns values", fun() ->
             C1 = eval("type Box value Int .", af_interpreter:new_continuation()),
             _C2 = eval(": get-value Box -> Box Int ; value .", C1),
-            State = {'Box', #{value => {'Int', 99}}},
+            State = {'Box', 99},
             {ReturnValues, _NewState} = af_otp_dispatch:call_word("get-value", [], State),
             ?assertEqual([99], ReturnValues)
         end} end,
         fun(_) -> {"dispatch cast_word modifies state", fun() ->
             C1 = eval("type Box value Int .", af_interpreter:new_continuation()),
             _C2 = eval(": set-42 Box -> Box ; 42 value! .", C1),
-            State = {'Box', #{value => {'Int', 0}}},
-            {'Box', NewFields} = af_otp_dispatch:cast_word("set-42", [], State),
-            ?assertEqual({'Int', 42}, maps:get(value, NewFields))
+            State = {'Box', 0},
+            NewState = af_otp_dispatch:cast_word("set-42", [], State),
+            ?assertEqual('Box', element(1, NewState)),
+            ?assertEqual(42, element(2, NewState))
         end} end
     ]}.
 
@@ -90,7 +91,7 @@ error_path_test_() ->
             _C2 = eval(": reset Acc -> Acc ; 0 value! .", C1),
             C3 = eval("af_gs_acc Acc gen-server-module", _C2),
             [{'Atom', "af_gs_acc"}] = C3#continuation.data_stack,
-            InitState = {'Acc', #{value => {'Int', 10}}},
+            InitState = {'Acc', 10},
             {ok, Pid} = gen_server:start_link(af_gs_acc, InitState, []),
             ok = gen_server:cast(Pid, reset),
             timer:sleep(50),
@@ -104,7 +105,7 @@ error_path_test_() ->
             _C2 = eval(": get-both Pair -> Pair Int Int ; a swap b swap .", C1),
             C3 = eval("af_gs_pair Pair gen-server-module", _C2),
             [{'Atom', "af_gs_pair"}] = C3#continuation.data_stack,
-            InitState = {'Pair', #{a => {'Int', 1}, b => {'Int', 2}}},
+            InitState = {'Pair', 1, 2},
             {ok, Pid} = gen_server:start_link(af_gs_pair, InitState, []),
             {ok, Result} = gen_server:call(Pid, 'get-both'),
             %% Multi-return: result is list of raw values
@@ -127,7 +128,7 @@ error_path_test_() ->
             C3 = eval("\"get-val\" compile", C2),
             C4 = eval("af_gs_ncounter NCounter gen-server-module", C3),
             [{'Atom', "af_gs_ncounter"}] = C4#continuation.data_stack,
-            InitState = {'NCounter', #{val => {'Int', 77}}},
+            InitState = {'NCounter', 77},
             {ok, Pid} = gen_server:start_link(af_gs_ncounter, InitState, []),
             {ok, Val} = gen_server:call(Pid, 'get-val'),
             ?assertEqual(77, Val),

--- a/test/af_product_tests.erl
+++ b/test/af_product_tests.erl
@@ -23,51 +23,53 @@ product_type_test_() ->
         fun(_) -> {"construct a product type instance", fun() ->
             C1 = eval("type Point x Int y Int .", af_interpreter:new_continuation()),
             C2 = eval("10 int 20 int point", C1),
-            [{TypeName, FieldMap}] = C2#continuation.data_stack,
-            ?assertEqual('Point', TypeName),
-            ?assertEqual({'Int', 10}, maps:get(x, FieldMap)),
-            ?assertEqual({'Int', 20}, maps:get(y, FieldMap))
+            %% New storage: {TypeName, V1, V2, ...} with raw field values.
+            [Instance] = C2#continuation.data_stack,
+            ?assertEqual('Point', element(1, Instance)),
+            ?assertEqual(10, element(2, Instance)),
+            ?assertEqual(20, element(3, Instance))
         end} end,
         fun(_) -> {"getter is non-destructive (leaves instance on stack)", fun() ->
             C1 = eval("type Point x Int y Int .", af_interpreter:new_continuation()),
             C2 = eval("10 int 20 int point x", C1),
-            %% Non-destructive: value on TOS, instance below
-            [{'Int', 10}, {'Point', _}] = C2#continuation.data_stack
+            %% Non-destructive: tagged value on TOS, instance below
+            [{'Int', 10}, Instance] = C2#continuation.data_stack,
+            ?assertEqual('Point', element(1, Instance))
         end} end,
         fun(_) -> {"getter retrieves second field", fun() ->
             C1 = eval("type Point x Int y Int .", af_interpreter:new_continuation()),
             C2 = eval("10 int 20 int point y", C1),
-            [{'Int', 20}, {'Point', _}] = C2#continuation.data_stack
+            [{'Int', 20}, Instance] = C2#continuation.data_stack,
+            ?assertEqual('Point', element(1, Instance))
         end} end,
         fun(_) -> {"multiple getters chain without dup", fun() ->
             C1 = eval("type Point x Int y Int .", af_interpreter:new_continuation()),
             C2 = eval("10 int 20 int point x swap y", C1),
-            %% After x: [Int(10), Point]
-            %% After swap: [Point, Int(10)]
-            %% After y: [Int(20), Point, Int(10)]
-            [{'Int', 20}, {'Point', _}, {'Int', 10}] = C2#continuation.data_stack
+            [{'Int', 20}, Instance, {'Int', 10}] = C2#continuation.data_stack,
+            ?assertEqual('Point', element(1, Instance))
         end} end,
         fun(_) -> {"setter updates field value", fun() ->
             C1 = eval("type Point x Int y Int .", af_interpreter:new_continuation()),
             C2 = eval("10 int 20 int point 99 int x!", C1),
-            [{TypeName, FieldMap}] = C2#continuation.data_stack,
-            ?assertEqual('Point', TypeName),
-            ?assertEqual({'Int', 99}, maps:get(x, FieldMap)),
-            ?assertEqual({'Int', 20}, maps:get(y, FieldMap))
+            [Instance] = C2#continuation.data_stack,
+            ?assertEqual('Point', element(1, Instance)),
+            ?assertEqual(99, element(2, Instance)),
+            ?assertEqual(20, element(3, Instance))
         end} end,
         fun(_) -> {"product type with single field", fun() ->
             C1 = eval("type Wrapper val Int .", af_interpreter:new_continuation()),
             C2 = eval("42 int wrapper val", C1),
-            [{'Int', 42}, {'Wrapper', _}] = C2#continuation.data_stack
+            [{'Int', 42}, Instance] = C2#continuation.data_stack,
+            ?assertEqual('Wrapper', element(1, Instance))
         end} end,
         fun(_) -> {"product type with three fields", fun() ->
             C1 = eval("type Color r Int g Int b Int .", af_interpreter:new_continuation()),
             C2 = eval("255 int 128 int 0 int color", C1),
-            [{TypeName, FieldMap}] = C2#continuation.data_stack,
-            ?assertEqual('Color', TypeName),
-            ?assertEqual({'Int', 255}, maps:get(r, FieldMap)),
-            ?assertEqual({'Int', 128}, maps:get(g, FieldMap)),
-            ?assertEqual({'Int', 0}, maps:get(b, FieldMap))
+            [Instance] = C2#continuation.data_stack,
+            ?assertEqual('Color', element(1, Instance)),
+            ?assertEqual(255, element(2, Instance)),
+            ?assertEqual(128, element(3, Instance)),
+            ?assertEqual(0, element(4, Instance))
         end} end,
         fun(_) -> {"product type works with compiled words", fun() ->
             C1 = eval("type Point x Int y Int .", af_interpreter:new_continuation()),
@@ -103,23 +105,26 @@ field_update_pattern_test_() ->
             %% swap drop: -> [Counter(val=15)]
             C2 = eval(": add-value Counter Int -> Counter ; over value rot + value! swap drop .", C1),
             C3 = eval("10 counter 5 add-value", C2),
-            [{'Counter', Fields}] = C3#continuation.data_stack,
-            ?assertEqual({'Int', 15}, maps:get(value, Fields))
+            [Instance] = C3#continuation.data_stack,
+            ?assertEqual('Counter', element(1, Instance)),
+            ?assertEqual(15, element(2, Instance))
         end} end,
 
         fun(_) -> {"field subtract pattern works correctly", fun() ->
             C1 = eval("type Counter value Int .", af_interpreter:new_continuation()),
             C2 = eval(": sub-value Counter Int -> Counter ; over value rot - value! swap drop .", C1),
             C3 = eval("10 counter 3 sub-value", C2),
-            [{'Counter', Fields}] = C3#continuation.data_stack,
-            ?assertEqual({'Int', 7}, maps:get(value, Fields))
+            [Instance] = C3#continuation.data_stack,
+            ?assertEqual('Counter', element(1, Instance)),
+            ?assertEqual(7, element(2, Instance))
         end} end,
 
         fun(_) -> {"chained field updates preserve state", fun() ->
             C1 = eval("type Counter value Int .", af_interpreter:new_continuation()),
             C2 = eval(": add-value Counter Int -> Counter ; over value rot + value! swap drop .", C1),
             C3 = eval("0 counter 10 add-value 20 add-value 30 add-value", C2),
-            [{'Counter', Fields}] = C3#continuation.data_stack,
-            ?assertEqual({'Int', 60}, maps:get(value, Fields))
+            [Instance] = C3#continuation.data_stack,
+            ?assertEqual('Counter', element(1, Instance)),
+            ?assertEqual(60, element(2, Instance))
         end} end
     ]}.

--- a/test/af_term_tests.erl
+++ b/test/af_term_tests.erl
@@ -1,6 +1,7 @@
 -module(af_term_tests).
 
 -include_lib("eunit/include/eunit.hrl").
+-include("af_type.hrl").
 
 %% --- to_stack_item ---
 
@@ -87,7 +88,12 @@ from_stack_item_test_() ->
                          af_term:from_stack_item({'Actor', #{pid => self(), type_name => t, vocab => #{}}}))
         end},
         {"product type becomes map with type key", fun() ->
-            Instance = {'Point', #{x => {'Int', 10}, y => {'Int', 20}}},
+            %% Register the type so from_stack_item can find its field layout.
+            af_type:reset(),
+            af_type:register_type(#af_type{name = 'Point',
+                                            fields = [{x, 'Int'}, {y, 'Int'}]}),
+            %% New storage: positional tuple with raw values.
+            Instance = {'Point', 10, 20},
             Result = af_term:from_stack_item(Instance),
             ?assertEqual(#{type => 'Point', x => 10, y => 20}, Result)
         end}

--- a/test/af_type_otp_tests.erl
+++ b/test/af_type_otp_tests.erl
@@ -19,7 +19,7 @@ gen_server_test_() ->
             C3 = eval(": peek Gadget -> Gadget Int ; value .", C2),
             C4 = eval("af_gs_gadget Gadget gen-server-module", C3),
             [{'Atom', "af_gs_gadget"}] = C4#continuation.data_stack,
-            InitState = {'Gadget', #{value => {'Int', 0}}},
+            InitState = {'Gadget', 0},
             {ok, Pid} = gen_server:start_link(af_gs_gadget, InitState, []),
             %% cast bump (async)
             ok = gen_server:cast(Pid, bump),
@@ -65,7 +65,7 @@ gen_server_test_() ->
             C2 = eval(": getval Item -> Item Int ; val .", C1),
             C3 = eval("af_gs_item Item gen-server-module", C2),
             [{'Atom', "af_gs_item"}] = C3#continuation.data_stack,
-            InitState = {'Item', #{val => {'Int', 55}}},
+            InitState = {'Item', 55},
             {ok, Pid} = gen_server:start_link(af_gs_item, InitState, []),
             {ok, 55} = gen_server:call(Pid, getval),
             gen_server:stop(Pid)
@@ -76,7 +76,7 @@ gen_server_test_() ->
             C2 = eval(": peek-fin Fin -> Fin Int ; val .", C1),
             C3 = eval("af_gs_fin Fin gen-server-module", C2),
             [{'Atom', "af_gs_fin"}] = C3#continuation.data_stack,
-            InitState = {'Fin', #{val => {'Int', 1}}},
+            InitState = {'Fin', 1},
             {ok, Pid} = gen_server:start_link(af_gs_fin, InitState, []),
             {ok, 1} = gen_server:call(Pid, 'peek-fin'),
             %% Stopping exercises terminate/2

--- a/test/af_word_compiler_tests.erl
+++ b/test/af_word_compiler_tests.erl
@@ -1054,7 +1054,9 @@ product_ops_test_() ->
             C2 = eval(": test-getx Point -> Point Int ; x .", C1),
             C3 = eval("\"test-getx\" compile", C2),
             C4 = eval("3 int 5 int point test-getx", C3),
-            [{'Int', 3}, {'Point', _}] = C4#continuation.data_stack
+            %% New storage: product instance is a positional tuple, not a map.
+            [{'Int', 3}, Instance] = C4#continuation.data_stack,
+            ?assertEqual('Point', element(1, Instance))
         end} end,
 
         fun(_) -> {"product setter compiles to native BEAM", fun() ->
@@ -1063,8 +1065,9 @@ product_ops_test_() ->
             C2 = eval(": test-setx Point Int -> Point ; x! .", C1),
             C3 = eval("\"test-setx\" compile", C2),
             C4 = eval("3 int 5 int point 99 test-setx", C3),
-            [{'Point', Fields}] = C4#continuation.data_stack,
-            ?assertEqual({'Int', 99}, maps:get(x, Fields))
+            [Instance] = C4#continuation.data_stack,
+            ?assertEqual('Point', element(1, Instance)),
+            ?assertEqual(99, element(2, Instance))
         end} end,
 
         fun(_) -> {"product getter-then-op compiles to native BEAM", fun() ->
@@ -1073,8 +1076,9 @@ product_ops_test_() ->
             C2 = eval(": test-inc Counter -> Counter ; value 1 int + value! .", C1),
             C3 = eval("\"test-inc\" compile", C2),
             C4 = eval("0 int counter test-inc", C3),
-            [{'Counter', Fields}] = C4#continuation.data_stack,
-            ?assertEqual({'Int', 1}, maps:get(value, Fields))
+            [Instance] = C4#continuation.data_stack,
+            ?assertEqual('Counter', element(1, Instance)),
+            ?assertEqual(1, element(2, Instance))
         end} end
     ]}.
 

--- a/test/demos/comprehensive/bench_ops.escript
+++ b/test/demos/comprehensive/bench_ops.escript
@@ -248,9 +248,9 @@ run_direct_map(N) ->
 
 run_direct_product(N) ->
     lists:foreach(fun(I) ->
-        %% Construct Vec3 instance directly (what the constructor does)
-        FieldMap = #{x => {'Int', I}, y => {'Int', I+1}, z => {'Int', I+2}},
-        Instance = {'Vec3', FieldMap},
+        %% Construct Vec3 instance directly (what the constructor does).
+        %% New storage: positional tuple with raw values.
+        Instance = {'Vec3', I, I+1, I+2},
         'af_native_vec-mag2':'vec-mag2'([Instance])
     end, lists:seq(1, N)).
 

--- a/test/demos/comprehensive/results/2026-04-17-210417.json
+++ b/test/demos/comprehensive/results/2026-04-17-210417.json
@@ -1,0 +1,87 @@
+{
+  "date": "2026-04-17T14:04:17Z",
+  "git_sha": "3057e8f",
+  "quick": false,
+  "results": {
+    "a4_cpp": {
+      "arith": 0.267,
+      "list": 1.141,
+      "map": 0.687,
+      "product": 0.753,
+      "string": 0.148,
+      "wordchain": 0.322
+    },
+    "a4_direct": {
+      "arith": 0.081,
+      "list": 0.048,
+      "map": 0.105,
+      "product": 0.766,
+      "string": 0.677,
+      "wordchain": 1.18
+    },
+    "a4_interp": {
+      "arith": 2.448,
+      "list": 4.308,
+      "map": 2.117,
+      "product": 4.078,
+      "string": 1.345,
+      "wordchain": 2.463
+    },
+    "a4_native": {
+      "arith": 0.382,
+      "list": 4.23,
+      "map": 2.203,
+      "product": 1.5,
+      "string": 0.993,
+      "wordchain": 1.535
+    },
+    "cpp": {
+      "arith": 0.0,
+      "list": 0.024,
+      "map": 0.079,
+      "product": 0.001,
+      "string": 0.044,
+      "wordchain": 0.0
+    },
+    "elixir": {
+      "arith": 0.019,
+      "list": 0.042,
+      "map": 0.029,
+      "product": 0.026,
+      "string": 0.295,
+      "wordchain": 0.019
+    },
+    "erlang": {
+      "arith": 0.025,
+      "list": 0.057,
+      "map": 0.116,
+      "product": 0.031,
+      "string": 0.616,
+      "wordchain": 0.023
+    },
+    "python": {
+      "arith": 0.112,
+      "list": 0.218,
+      "map": 0.164,
+      "product": 0.242,
+      "string": 0.084,
+      "wordchain": 0.162
+    },
+    "ts_interp": {
+      "arith": 10.226,
+      "list": 18.753,
+      "map": 12.656,
+      "product": 17.34,
+      "string": 2.775,
+      "wordchain": 10.412
+    },
+    "ts_native": {
+      "arith": 0.001,
+      "list": 0.156,
+      "map": 0.066,
+      "product": 0.021,
+      "string": 0.014,
+      "wordchain": 0.001
+    }
+  }
+}


### PR DESCRIPTION
Changes product type instance storage from `{TypeName, #{field => {FieldType, Value}}}` to `{TypeName, V1, V2, ..., Vn}` — a positional tagged tuple with raw values at known offsets.

## Why

Field access goes from `maps:get(field, FieldMap) -> {Int, V}` (a map lookup + tagged-tuple allocation per field value) to `element(N, Instance)` (a single BEAM instruction returning the raw value). Setters go from `maps:put(...)` (map rebuild) to `setelement(N, ...)` (one-element rewrite).

## Shape

- `#af_type{}` gains `fields = [{FieldName, FieldType}, ...]` so we can map names to positions.
- Getter impl: `element(Pos, Instance)` + re-tag with FieldType for stack convention.
- Setter impl: `setelement(Pos, Instance, NewRawVal)`.
- Constructor: `list_to_tuple([TypeName | RawVals])`.

## Scope

- `af_type_product.erl` rewritten
- `af_word_compiler.erl` try_product_op uses element/setelement
- `af_term.erl` decodes the new shape back into Erlang maps for FFI
- `af_type` / `af_interpreter` / `af_type_actor` dispatch paths accept N-tuples, not just 2-tuples
- Ring 0 product ops unchanged (independent VM; separate concern)
- Consumer tests updated

## Tests

**2146 passing** — same as before this PR.

## Benchmark delta (post-PR #36 baseline)

Modest (~4% on Product type benchmark). The BEAM JIT already optimised much of the old map path; the bigger wins from this refactor are architectural (simpler code, one allocation per setter instead of two, closer to Erlang record semantics). Perf will compound with future unboxing work.